### PR TITLE
fix: support compose.yml / compose.yaml as default compose file names

### DIFF
--- a/Sources/Mocker/Commands/Compose.swift
+++ b/Sources/Mocker/Commands/Compose.swift
@@ -21,13 +21,16 @@ struct ComposeCommand: AsyncParsableCommand {
 
 struct ComposeOptions: ParsableArguments {
     @Option(name: [.customShort("f"), .long], help: "Compose file path")
-    var file: String = "docker-compose.yml"
+    var file: String?
 
     @Option(name: [.customShort("p"), .customLong("project-name")], help: "Project name")
     var projectName: String?
 
     func loadCompose() throws -> (ComposeFile, String) {
-        let path = file
+        guard let path = file ?? ComposeFile.findDefault() else {
+            let searched = ComposeFile.defaultFileNames.joined(separator: ", ")
+            throw MockerError.composeFileNotFound("No compose file found. Searched for: \(searched)")
+        }
         let composeFile = try ComposeFile.load(from: path)
 
         // Derive project name from directory if not specified

--- a/Sources/MockerKit/Compose/ComposeFile.swift
+++ b/Sources/MockerKit/Compose/ComposeFile.swift
@@ -17,6 +17,20 @@ public struct ComposeFile: Sendable {
         self.volumes = volumes
     }
 
+    /// Default compose file names searched in order, matching Docker Compose V2 behaviour.
+    public static let defaultFileNames = ["compose.yaml", "compose.yml", "docker-compose.yaml", "docker-compose.yml"]
+
+    /// Return the path of the first default compose file found in `directory`.
+    public static func findDefault(in directory: String = FileManager.default.currentDirectoryPath) -> String? {
+        for name in defaultFileNames {
+            let path = URL(fileURLWithPath: directory).appendingPathComponent(name).path
+            if FileManager.default.fileExists(atPath: path) {
+                return path
+            }
+        }
+        return nil
+    }
+
     /// Parse a docker-compose.yml file from a path.
     public static func load(from path: String) throws -> ComposeFile {
         let url = URL(fileURLWithPath: path)

--- a/Tests/MockerKitTests/ComposeFileTests.swift
+++ b/Tests/MockerKitTests/ComposeFileTests.swift
@@ -1,4 +1,5 @@
 import Testing
+import Foundation
 @testable import MockerKit
 
 @Suite("ComposeFile Tests")
@@ -133,5 +134,66 @@ struct ComposeFileTests {
         let compose = try ComposeFile.parse(yaml)
         #expect(compose.services["app"]?.build?.context == "./app")
         #expect(compose.services["app"]?.build?.dockerfile == "Dockerfile.dev")
+    }
+
+    @Test("findDefault returns nil when no compose file exists in empty directory")
+    func findDefaultNoFile() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        #expect(ComposeFile.findDefault(in: dir) == nil)
+    }
+
+    @Test("findDefault finds compose.yml before docker-compose.yml")
+    func findDefaultPreferCompose() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let composePath = URL(fileURLWithPath: dir).appendingPathComponent("compose.yml").path
+        let dockerComposePath = URL(fileURLWithPath: dir).appendingPathComponent("docker-compose.yml").path
+        FileManager.default.createFile(atPath: composePath, contents: Data())
+        FileManager.default.createFile(atPath: dockerComposePath, contents: Data())
+
+        let found = ComposeFile.findDefault(in: dir)
+        #expect(found == composePath)
+    }
+
+    @Test("findDefault finds compose.yaml before compose.yml")
+    func findDefaultPreferYaml() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let yamlPath = URL(fileURLWithPath: dir).appendingPathComponent("compose.yaml").path
+        let ymlPath = URL(fileURLWithPath: dir).appendingPathComponent("compose.yml").path
+        FileManager.default.createFile(atPath: yamlPath, contents: Data())
+        FileManager.default.createFile(atPath: ymlPath, contents: Data())
+
+        let found = ComposeFile.findDefault(in: dir)
+        #expect(found == yamlPath)
+    }
+
+    @Test("findDefault falls back to docker-compose.yml when only it exists")
+    func findDefaultFallback() throws {
+        let dir = try makeTempDir()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let path = URL(fileURLWithPath: dir).appendingPathComponent("docker-compose.yml").path
+        FileManager.default.createFile(atPath: path, contents: Data())
+
+        let found = ComposeFile.findDefault(in: dir)
+        #expect(found == path)
+    }
+
+    @Test("defaultFileNames contains expected filenames in correct order")
+    func defaultFileNamesOrder() {
+        #expect(ComposeFile.defaultFileNames == ["compose.yaml", "compose.yml", "docker-compose.yaml", "docker-compose.yml"])
+    }
+
+    // MARK: - Helpers
+
+    private func makeTempDir() throws -> String {
+        let dir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString).path
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        return dir
     }
 }


### PR DESCRIPTION
`mocker compose` only resolved `docker-compose.yml` as the default config file, ignoring the preferred filenames introduced in Docker Compose V2.

## Changes

- **`ComposeFile`** — adds `defaultFileNames` (ordered: `compose.yaml`, `compose.yml`, `docker-compose.yaml`, `docker-compose.yml`) and `findDefault(in:)` which returns the first match in a given directory, mirroring Docker Compose V2 lookup behaviour
- **`ComposeOptions.file`** — changed from `String = "docker-compose.yml"` to `String?`; resolves via `findDefault()` when `-f` is not passed; error message now lists all searched filenames
- **Tests** — 5 new cases covering priority order (`compose.yaml` > `compose.yml` > `docker-compose.yaml` > `docker-compose.yml`), fallback, and nil when none found

```
# Previously failed — now works
$ ls compose.yml
compose.yml
$ mocker compose up
[+] Running …
```