### PR TITLE
feat: implement Docker/Podman socket compatibility via launchd activation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - name: Integration test – Docker CLI
         run: |
           SOCK=/tmp/mocker-ci-docker.sock
-          .build/release/mocker system service --socket-path "$SOCK" --timeout 60s &
+          .build/release/mocker system service --socket-path "$SOCK" --timeout 120s &
           SERVICE_PID=$!
 
           for i in $(seq 1 30); do
@@ -82,13 +82,15 @@ jobs:
           docker ps
           docker images
 
+          echo "docker run alpine cat /etc/os-release:"
+          docker run --rm alpine cat /etc/os-release
           echo "Docker CLI: OK"
           kill $SERVICE_PID 2>/dev/null || true
 
       - name: Integration test – Podman CLI
         run: |
           SOCK=/tmp/mocker-ci-podman.sock
-          .build/release/mocker system service --socket-path "$SOCK" --timeout 60s &
+          .build/release/mocker system service --socket-path "$SOCK" --timeout 120s &
           SERVICE_PID=$!
 
           for i in $(seq 1 30); do
@@ -99,10 +101,12 @@ jobs:
           curl -sf --unix-socket "$SOCK" http://localhost/_ping > /dev/null \
             || { echo "::error::socket not ready"; kill $SERVICE_PID 2>/dev/null || true; exit 1; }
 
-          # Set DOCKER_HOST so podman uses the Docker-compat API (not the libpod API)
-          export DOCKER_HOST="unix://$SOCK"
+          # Use CONTAINER_HOST so podman talks libpod API to our mocker socket
+          export CONTAINER_HOST="unix://$SOCK"
           podman version
           podman ps
 
+          echo "podman run alpine cat /etc/os-release:"
+          podman run --rm alpine cat /etc/os-release
           echo "Podman CLI: OK"
           kill $SERVICE_PID 2>/dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main]
   push:
-    branches: [main, copilot/implement-mocker-enhancement-7]
+    branches: [main]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,8 @@ jobs:
             https://github.com/apple/container/releases/download/0.12.3/container-installer-unsigned.pkg
           sudo installer -pkg /tmp/container.pkg -target /
           # Start the service now so it initialises while Docker/Podman are being installed
-          container system start
+          # Pipe 'y' to automatically accept the default kernel installation prompt in non-interactive CI
+          printf 'y\n' | container system start || true
 
       - name: Install Docker and Podman CLIs
         run: brew install --quiet docker podman

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,16 @@ jobs:
             https://github.com/apple/container/releases/download/0.12.3/container-installer-unsigned.pkg
           sudo installer -pkg /tmp/container.pkg -target /
 
+      - name: Start Apple container system service
+        run: |
+          container system start
+          # Wait up to 60 s for the service to become ready
+          for i in $(seq 1 60); do
+            container system info > /dev/null 2>&1 && echo "container system ready" && break
+            sleep 1
+          done
+          container system info
+
       - name: Install Docker and Podman CLIs
         run: brew install --quiet docker podman
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
           done
 
           curl -sf --unix-socket "$SOCK" http://localhost/_ping > /dev/null \
-            || { echo "::error::/_ping did not respond"; kill $SERVICE_PID; exit 1; }
+            || { echo "::error::/_ping did not respond"; kill $SERVICE_PID 2>/dev/null || true; exit 1; }
 
           echo "/_ping: OK"
 
@@ -61,7 +61,7 @@ jobs:
             | python3 -c "import sys,json; d=json.load(sys.stdin); assert isinstance(d,list), f'expected array: {d}'"
           echo "/images/json: OK"
 
-          kill $SERVICE_PID
+          kill $SERVICE_PID 2>/dev/null || true
 
       - name: Integration test – Docker CLI
         run: |
@@ -75,7 +75,7 @@ jobs:
           done
 
           curl -sf --unix-socket "$SOCK" http://localhost/_ping > /dev/null \
-            || { echo "::error::socket not ready"; kill $SERVICE_PID; exit 1; }
+            || { echo "::error::socket not ready"; kill $SERVICE_PID 2>/dev/null || true; exit 1; }
 
           export DOCKER_HOST="unix://$SOCK"
           docker version
@@ -83,7 +83,7 @@ jobs:
           docker images
 
           echo "Docker CLI: OK"
-          kill $SERVICE_PID
+          kill $SERVICE_PID 2>/dev/null || true
 
       - name: Integration test – Podman CLI
         run: |
@@ -97,10 +97,12 @@ jobs:
           done
 
           curl -sf --unix-socket "$SOCK" http://localhost/_ping > /dev/null \
-            || { echo "::error::socket not ready"; kill $SERVICE_PID; exit 1; }
+            || { echo "::error::socket not ready"; kill $SERVICE_PID 2>/dev/null || true; exit 1; }
 
-          podman --url "unix://$SOCK" version
-          podman --url "unix://$SOCK" ps
+          # Set DOCKER_HOST so podman uses the Docker-compat API (not the libpod API)
+          export DOCKER_HOST="unix://$SOCK"
+          podman version
+          podman ps
 
           echo "Podman CLI: OK"
-          kill $SERVICE_PID
+          kill $SERVICE_PID 2>/dev/null || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,8 @@ jobs:
             https://github.com/apple/container/releases/download/0.12.3/container-installer-unsigned.pkg
           sudo installer -pkg /tmp/container.pkg -target /
           # Start the service now so it initialises while Docker/Podman are being installed
-          # Pipe 'y' to automatically accept the default kernel installation prompt in non-interactive CI
-          printf 'y\n' | container system start || true
+          # --enable-kernel-install skips the interactive kernel installation prompt in non-interactive CI
+          container system start --enable-kernel-install
 
       - name: Install Docker and Podman CLIs
         run: brew install --quiet docker podman

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [main]
   push:
-    branches: [main]
+    branches: [main, copilot/implement-mocker-enhancement-7]
 
 jobs:
   test:
@@ -25,3 +25,82 @@ jobs:
 
       - name: Test
         run: swift test
+
+      - name: Build release binary
+        run: swift build -c release --product mocker
+
+      - name: Install Docker and Podman CLIs
+        run: brew install --quiet docker podman
+
+      - name: Integration test – socket via curl
+        run: |
+          SOCK=/tmp/mocker-ci-curl.sock
+          .build/release/mocker system service --socket-path "$SOCK" --timeout 60s &
+          SERVICE_PID=$!
+
+          # Wait up to 15 s for the server to respond on the socket
+          for i in $(seq 1 30); do
+            curl -sf --unix-socket "$SOCK" http://localhost/_ping > /dev/null 2>&1 && break
+            sleep 0.5
+          done
+
+          curl -sf --unix-socket "$SOCK" http://localhost/_ping > /dev/null \
+            || { echo "::error::/_ping did not respond"; kill $SERVICE_PID; exit 1; }
+
+          echo "/_ping: OK"
+
+          curl -sf --unix-socket "$SOCK" http://localhost/v1.47/version \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); assert d['ApiVersion']=='1.47', f'bad ApiVersion: {d}'"
+          echo "/version: OK"
+
+          curl -sf --unix-socket "$SOCK" http://localhost/v1.47/containers/json \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); assert isinstance(d,list), f'expected array: {d}'"
+          echo "/containers/json: OK"
+
+          curl -sf --unix-socket "$SOCK" http://localhost/v1.47/images/json \
+            | python3 -c "import sys,json; d=json.load(sys.stdin); assert isinstance(d,list), f'expected array: {d}'"
+          echo "/images/json: OK"
+
+          kill $SERVICE_PID
+
+      - name: Integration test – Docker CLI
+        run: |
+          SOCK=/tmp/mocker-ci-docker.sock
+          .build/release/mocker system service --socket-path "$SOCK" --timeout 60s &
+          SERVICE_PID=$!
+
+          for i in $(seq 1 30); do
+            curl -sf --unix-socket "$SOCK" http://localhost/_ping > /dev/null 2>&1 && break
+            sleep 0.5
+          done
+
+          curl -sf --unix-socket "$SOCK" http://localhost/_ping > /dev/null \
+            || { echo "::error::socket not ready"; kill $SERVICE_PID; exit 1; }
+
+          export DOCKER_HOST="unix://$SOCK"
+          docker version
+          docker ps
+          docker images
+
+          echo "Docker CLI: OK"
+          kill $SERVICE_PID
+
+      - name: Integration test – Podman CLI
+        run: |
+          SOCK=/tmp/mocker-ci-podman.sock
+          .build/release/mocker system service --socket-path "$SOCK" --timeout 60s &
+          SERVICE_PID=$!
+
+          for i in $(seq 1 30); do
+            curl -sf --unix-socket "$SOCK" http://localhost/_ping > /dev/null 2>&1 && break
+            sleep 0.5
+          done
+
+          curl -sf --unix-socket "$SOCK" http://localhost/_ping > /dev/null \
+            || { echo "::error::socket not ready"; kill $SERVICE_PID; exit 1; }
+
+          podman --url "unix://$SOCK" version
+          podman --url "unix://$SOCK" ps
+
+          echo "Podman CLI: OK"
+          kill $SERVICE_PID

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,19 +34,20 @@ jobs:
           curl -fsSL -o /tmp/container.pkg \
             https://github.com/apple/container/releases/download/0.12.3/container-installer-unsigned.pkg
           sudo installer -pkg /tmp/container.pkg -target /
-
-      - name: Start Apple container system service
-        run: |
+          # Start the service now so it initialises while Docker/Podman are being installed
           container system start
+
+      - name: Install Docker and Podman CLIs
+        run: brew install --quiet docker podman
+
+      - name: Wait for Apple container system service
+        run: |
           # Wait up to 60 s for the service to become ready
           for i in $(seq 1 60); do
             container system info > /dev/null 2>&1 && echo "container system ready" && break
             sleep 1
           done
           container system info
-
-      - name: Install Docker and Podman CLIs
-        run: brew install --quiet docker podman
 
       - name: Integration test – socket via curl
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,23 @@ jobs:
       - name: Wait for Apple container system service
         run: |
           # Wait up to 60 s for the service to become ready
+          ready=0
           for i in $(seq 1 60); do
-            container system status > /dev/null 2>&1 && echo "container system ready" && break
+            if container system status > /dev/null 2>&1; then
+              echo "container system ready (attempt $i)"
+              ready=1
+              break
+            fi
             sleep 1
           done
+          if [ "$ready" -eq 0 ]; then
+            echo "::error::container system did not become ready within 60 s"
+            container system status || true
+            exit 1
+          fi
+          # Status for "is it up?" and version for diagnostics
           container system status
+          container system version
 
       - name: Integration test – socket via curl
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,14 @@ jobs:
         with:
           xcode-version: latest-stable
 
+      - name: Cache Swift build artifacts
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: ${{ runner.os }}-swift-${{ hashFiles('Package.swift', 'Package.resolved', 'Sources/**/*.swift', 'Tests/**/*.swift') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-
+
       - name: Build
         run: swift build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,12 @@ jobs:
       - name: Build release binary
         run: swift build -c release --product mocker
 
+      - name: Install Apple container CLI
+        run: |
+          curl -fsSL -o /tmp/container.pkg \
+            https://github.com/apple/container/releases/download/0.12.3/container-installer-unsigned.pkg
+          sudo installer -pkg /tmp/container.pkg -target /
+
       - name: Install Docker and Podman CLIs
         run: brew install --quiet docker podman
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,10 @@ jobs:
         run: |
           # Wait up to 60 s for the service to become ready
           for i in $(seq 1 60); do
-            container system info > /dev/null 2>&1 && echo "container system ready" && break
+            container system status > /dev/null 2>&1 && echo "container system ready" && break
             sleep 1
           done
-          container system info
+          container system status
 
       - name: Integration test – socket via curl
         run: |

--- a/README.md
+++ b/README.md
@@ -345,23 +345,28 @@ podman run --rm alpine cat /etc/os-release
 
 **Alternative: symlink method (no environment variable)**
 
-Podman Desktop's Docker compatibility feature works by symlinking the default
-socket path. You can replicate this for Mocker:
+On macOS, when neither `CONTAINER_HOST` nor `XDG_RUNTIME_DIR` is set and no
+Podman machine is running, Podman falls back to
+`$TMPDIR/storage-run-$(id -u)/podman/podman.sock`
+([source](https://github.com/containers/storage/blob/main/pkg/homedir/homedir_unix.go)).
+`$TMPDIR` on macOS resolves to `/var/folders/…/<hash>/T/` — a stable per-user
+path that persists across reboots. Create the directory and symlink Mocker's
+socket there:
 
 ```bash
-# Point Podman's default machine socket to Mocker's socket
-PODMAN_SOCK_DIR="$HOME/.local/share/containers/podman/machine/qemu"
+# Point Podman's default socket to Mocker's socket (macOS)
+PODMAN_SOCK_DIR="${TMPDIR%/}/storage-run-$(id -u)/podman"
 mkdir -p "$PODMAN_SOCK_DIR"
 ln -sf "$HOME/.mocker/mocker.sock" "$PODMAN_SOCK_DIR/podman.sock"
 
-# Now works without any env var (uses Podman's default socket search path)
+# Now works without any env var
 podman version
 podman ps
 ```
 
 To undo:
 ```bash
-rm "$HOME/.local/share/containers/podman/machine/qemu/podman.sock"
+rm "${TMPDIR%/}/storage-run-$(id -u)/podman/podman.sock"
 ```
 
 #### Automatic startup via launchd (macOS)

--- a/README.md
+++ b/README.md
@@ -309,6 +309,30 @@ docker images         # lists images via mocker
 docker run --rm alpine cat /etc/os-release
 ```
 
+**Alternative: symlink method (no environment variable)**
+
+Create a symlink at the default Docker socket path so Docker CLI finds Mocker
+without any `DOCKER_HOST` setting — the same approach Podman Desktop uses for
+its Docker compatibility mode:
+
+```bash
+# Point the default Docker socket to Mocker's socket
+sudo ln -sf "$HOME/.mocker/mocker.sock" /var/run/docker.sock
+
+# Now works without any env var
+docker version
+docker ps
+```
+
+To undo:
+```bash
+sudo rm /var/run/docker.sock
+```
+
+> **Note:** `/var/run/docker.sock` is owned by root on macOS. If another tool
+> (Docker Desktop, Podman Desktop) is already symlinking that path, this will
+> override it. Set `DOCKER_HOST` instead if you need both tools available.
+
 #### Use with Podman CLI
 
 ```bash
@@ -317,6 +341,27 @@ export CONTAINER_HOST="unix://$HOME/.mocker/mocker.sock"
 podman version
 podman ps
 podman run --rm alpine cat /etc/os-release
+```
+
+**Alternative: symlink method (no environment variable)**
+
+Podman Desktop's Docker compatibility feature works by symlinking the default
+socket path. You can replicate this for Mocker:
+
+```bash
+# Point Podman's default machine socket to Mocker's socket
+PODMAN_SOCK_DIR="$HOME/.local/share/containers/podman/machine/qemu"
+mkdir -p "$PODMAN_SOCK_DIR"
+ln -sf "$HOME/.mocker/mocker.sock" "$PODMAN_SOCK_DIR/podman.sock"
+
+# Now works without any env var (uses Podman's default socket search path)
+podman version
+podman ps
+```
+
+To undo:
+```bash
+rm "$HOME/.local/share/containers/podman/machine/qemu/podman.sock"
 ```
 
 #### Automatic startup via launchd (macOS)

--- a/README.md
+++ b/README.md
@@ -279,6 +279,93 @@ volumes:
   pgdata:
 ```
 
+### Socket Service (Docker / Podman CLI compatibility)
+
+`mocker system service` exposes a Docker-compatible REST API over a Unix socket.
+This lets the **Docker CLI**, **Podman CLI**, or any other Docker-API-speaking tool
+talk to Mocker without any code changes.
+
+#### Start the service
+
+```bash
+# Default socket path: ~/.mocker/mocker.sock
+mocker system service
+
+# Custom socket path
+mocker system service --socket-path /tmp/mocker.sock
+
+# Exit automatically after 60 s of inactivity
+mocker system service --socket-path /tmp/mocker.sock --timeout 60s
+```
+
+#### Use with Docker CLI
+
+```bash
+export DOCKER_HOST="unix://$HOME/.mocker/mocker.sock"
+
+docker version        # shows mocker's API version
+docker ps             # lists containers via mocker
+docker images         # lists images via mocker
+docker run --rm alpine cat /etc/os-release
+```
+
+#### Use with Podman CLI
+
+```bash
+export CONTAINER_HOST="unix://$HOME/.mocker/mocker.sock"
+
+podman version
+podman ps
+podman run --rm alpine cat /etc/os-release
+```
+
+#### Automatic startup via launchd (macOS)
+
+To have the socket service start on login and stay running in the background,
+register it as a launchd user agent. Create
+`~/Library/LaunchAgents/io.mocker.socket.plist`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.mocker.socket</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/mocker</string>
+    <string>system</string>
+    <string>service</string>
+  </array>
+  <key>Sockets</key>
+  <dict>
+    <key>MockerSocket</key>
+    <dict>
+      <key>SockFamily</key>
+      <string>Unix</string>
+      <key>SockPathName</key>
+      <string>/Users/YOUR_USERNAME/.mocker/mocker.sock</string>
+    </dict>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+</dict>
+</plist>
+```
+
+Then load it:
+
+```bash
+launchctl load ~/Library/LaunchAgents/io.mocker.socket.plist
+```
+
+When started this way, `mocker system service` automatically picks up the socket
+fd from launchd (socket activation) — no `--socket-path` flag is needed.
+
 ### System
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -350,9 +350,7 @@ register it as a launchd user agent. Create
     </dict>
   </dict>
   <key>RunAtLoad</key>
-  <true/>
-  <key>KeepAlive</key>
-  <true/>
+  <false/>
 </dict>
 </plist>
 ```

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ Your existing `docker-compose.yml` works as-is.
 
 ## What's New
 
+### v0.2.2 — Multi-arch builds & exotic-arch hints
+- **`mocker build --platform linux/arm64,linux/amd64,linux/ppc64le -t myimage .`** — multi-arch manifest build via Podman machine (all arches, one command)
+- Exotic-arch warning: `mocker build --platform linux/ppc64le` now prints an actionable hint before and after failure instead of a bare exit-code error
+- Podman machine is auto-detected; missing machine prints step-by-step recovery instructions
+
 ### v0.2.1 — Nested virtualization
 - **`--virtualization` / `--kernel`** for `mocker run` and `mocker create` — expose nested virtualization to containers (closes #4)
 
@@ -182,35 +187,63 @@ mocker push my-registry.io/myapp:latest
 
 #### Architecture support for builds
 
-| Architecture | `mocker build` | `mocker run` | Notes |
-|---|:---:|:---:|---|
-| `linux/arm64` | ✅ | ✅ | Native — Apple Silicon |
-| `linux/amd64` | ✅ | ✅ | Via Rosetta 2 hardware translation |
-| `linux/ppc64le` | ⚠️ | ❌ | Build works if no `RUN` steps; `RUN` fails (Exec format error) |
-| `linux/s390x` | ⚠️ | ❌ | Same limitation as ppc64le |
-| `linux/riscv64` | ⚠️ | ❌ | Same limitation |
+| Architecture | `mocker build` (single) | `mocker build` (multi-arch) | `mocker run` | Notes |
+|---|:---:|:---:|:---:|---|
+| `linux/arm64` | ✅ | ✅ | ✅ | Native — Apple Silicon |
+| `linux/amd64` | ✅ | ✅ | ✅ | Via Rosetta 2 hardware translation |
+| `linux/ppc64le` | ⚠️ | ✅* | ❌ | Single: `RUN` fails; Multi: via Podman machine QEMU |
+| `linux/s390x` | ⚠️ | ✅* | ❌ | Same as ppc64le |
+| `linux/riscv64` | ⚠️ | ✅* | ❌ | Same as ppc64le |
+
+\* Multi-arch builds for exotic arches require a running Podman machine (`podman machine start`).
 
 `linux/amd64` works seamlessly because Apple Silicon includes Rosetta 2 — hardware x86 translation. For other non-native architectures (ppc64le, s390x, riscv64), Dockerfiles with only `FROM`/`COPY`/`CMD` steps build successfully (layers are repackaged from the multi-arch base image), but any `RUN` instruction fails with `Exec format error` because Apple's build VM has no QEMU user-mode emulation for those ISAs.
 
 For comparison, Podman machine on macOS handles ppc64le/s390x `RUN` steps via QEMU inside its Fedora CoreOS VM — at the cost of a persistent shared VM.
 
-**Workarounds for exotic-arch `RUN` steps:**
+#### Multi-arch manifest builds
+
+`mocker build` accepts a comma-separated `--platform` list. When multiple platforms are specified, it builds each arch via Podman (which includes QEMU in its Fedora CoreOS VM) and assembles an OCI manifest list with `podman manifest create`:
 
 ```bash
-# Option 1: Remote builder (Linux box with QEMU binfmt)
+# Build a multi-arch manifest image (arm64 + amd64 + ppc64le)
+# Requires: podman machine start
+mocker build \
+  --platform linux/arm64,linux/amd64,linux/ppc64le \
+  -t myimage:latest \
+  .
+
+# Resulting images:
+#   myimage:latest-arm64   (linux/arm64)
+#   myimage:latest-amd64   (linux/amd64)
+#   myimage:latest-ppc64le (linux/ppc64le)
+#   myimage:latest         (manifest list → all three)
+```
+
+For single exotic-arch builds, mocker prints a warning with actionable hints before attempting the build.
+
+**Workarounds for exotic-arch `RUN` steps (single-arch):**
+
+```bash
+# Option 1: mocker multi-arch build (Podman machine required)
+podman machine start
+mocker build --platform linux/arm64,linux/ppc64le -t myimage .
+
+# Option 2: Podman directly
+podman machine start
+podman build --platform linux/ppc64le -t myimage:ppc64le .
+
+# Option 3: Remote builder (Linux box with QEMU binfmt)
 docker buildx create --driver docker-container \
   --platform linux/ppc64le,linux/s390x \
   ssh://user@your-linux-box
 docker buildx build --platform linux/ppc64le -t myimage:ppc64le .
 
-# Option 2: GitHub Actions (zero infrastructure)
+# Option 4: GitHub Actions (zero infrastructure)
 # Use docker/setup-qemu-action + docker/setup-buildx-action in CI
-
-# Option 3: Reuse a running Podman machine (already has QEMU)
-# See us/mocker#10 for tracking native support
 ```
 
-> **Tracking:** exotic-arch build support is tracked in [us/mocker#10](https://github.com/us/mocker/issues/10) and upstream in [apple/container#1496](https://github.com/apple/container/issues/1496).
+> **Tracking:** exotic-arch build support is tracked in [us/mocker#10](https://github.com/us/mocker/issues/10) and upstream in [apple/container#1496](https://github.com/apple/container/issues/1496). Manifest assembly workarounds (without Apple `container manifest`) are tracked in [us/mocker#11](https://github.com/us/mocker/issues/11).
 
 ### Inspect & Stats
 

--- a/README.md
+++ b/README.md
@@ -172,9 +172,45 @@ mocker rmi my-registry.io/alpine:v1
 # Build from Dockerfile
 mocker build -t myapp:latest .
 
+# Build for a specific architecture
+mocker build --platform linux/amd64 -t myapp:amd64 .
+mocker build --platform linux/arm64 -t myapp:arm64 .
+
 # Push to registry
 mocker push my-registry.io/myapp:latest
 ```
+
+#### Architecture support for builds
+
+| Architecture | `mocker build` | `mocker run` | Notes |
+|---|:---:|:---:|---|
+| `linux/arm64` | ✅ | ✅ | Native — Apple Silicon |
+| `linux/amd64` | ✅ | ✅ | Via Rosetta 2 hardware translation |
+| `linux/ppc64le` | ⚠️ | ❌ | Build works if no `RUN` steps; `RUN` fails (Exec format error) |
+| `linux/s390x` | ⚠️ | ❌ | Same limitation as ppc64le |
+| `linux/riscv64` | ⚠️ | ❌ | Same limitation |
+
+`linux/amd64` works seamlessly because Apple Silicon includes Rosetta 2 — hardware x86 translation. For other non-native architectures (ppc64le, s390x, riscv64), Dockerfiles with only `FROM`/`COPY`/`CMD` steps build successfully (layers are repackaged from the multi-arch base image), but any `RUN` instruction fails with `Exec format error` because Apple's build VM has no QEMU user-mode emulation for those ISAs.
+
+For comparison, Podman machine on macOS handles ppc64le/s390x `RUN` steps via QEMU inside its Fedora CoreOS VM — at the cost of a persistent shared VM.
+
+**Workarounds for exotic-arch `RUN` steps:**
+
+```bash
+# Option 1: Remote builder (Linux box with QEMU binfmt)
+docker buildx create --driver docker-container \
+  --platform linux/ppc64le,linux/s390x \
+  ssh://user@your-linux-box
+docker buildx build --platform linux/ppc64le -t myimage:ppc64le .
+
+# Option 2: GitHub Actions (zero infrastructure)
+# Use docker/setup-qemu-action + docker/setup-buildx-action in CI
+
+# Option 3: Reuse a running Podman machine (already has QEMU)
+# See us/mocker#10 for tracking native support
+```
+
+> **Tracking:** exotic-arch build support is tracked in [us/mocker#10](https://github.com/us/mocker/issues/10) and upstream in [apple/container#1496](https://github.com/apple/container/issues/1496).
 
 ### Inspect & Stats
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -278,6 +278,92 @@ volumes:
   pgdata:
 ```
 
+### Socket 服务（Docker / Podman CLI 兼容）
+
+`mocker system service` 通过 Unix socket 暴露 Docker 兼容的 REST API。
+这使得 **Docker CLI**、**Podman CLI** 或任何支持 Docker API 的工具
+无需修改代码即可与 Mocker 通信。
+
+#### 启动服务
+
+```bash
+# 默认 socket 路径：~/.mocker/mocker.sock
+mocker system service
+
+# 自定义 socket 路径
+mocker system service --socket-path /tmp/mocker.sock
+
+# 60 秒无活动后自动退出
+mocker system service --socket-path /tmp/mocker.sock --timeout 60s
+```
+
+#### 配合 Docker CLI 使用
+
+```bash
+export DOCKER_HOST="unix://$HOME/.mocker/mocker.sock"
+
+docker version        # 显示 mocker 的 API 版本
+docker ps             # 通过 mocker 列出容器
+docker images         # 通过 mocker 列出镜像
+docker run --rm alpine cat /etc/os-release
+```
+
+#### 配合 Podman CLI 使用
+
+```bash
+export CONTAINER_HOST="unix://$HOME/.mocker/mocker.sock"
+
+podman version
+podman ps
+podman run --rm alpine cat /etc/os-release
+```
+
+#### 通过 launchd 自动启动（macOS）
+
+如需在登录时自动启动 socket 服务并在后台保持运行，可将其注册为 launchd 用户代理。
+创建 `~/Library/LaunchAgents/io.mocker.socket.plist`：
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>io.mocker.socket</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/usr/local/bin/mocker</string>
+    <string>system</string>
+    <string>service</string>
+  </array>
+  <key>Sockets</key>
+  <dict>
+    <key>MockerSocket</key>
+    <dict>
+      <key>SockFamily</key>
+      <string>Unix</string>
+      <key>SockPathName</key>
+      <string>/Users/YOUR_USERNAME/.mocker/mocker.sock</string>
+    </dict>
+  </dict>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+</dict>
+</plist>
+```
+
+然后加载：
+
+```bash
+launchctl load ~/Library/LaunchAgents/io.mocker.socket.plist
+```
+
+通过此方式启动时，`mocker system service` 会自动从 launchd 获取 socket 文件描述符
+（socket 激活），无需 `--socket-path` 参数。
+
 ### 系统管理
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -318,6 +318,30 @@ podman ps
 podman run --rm alpine cat /etc/os-release
 ```
 
+**替代方案：符号链接（无需环境变量）**
+
+在 macOS 上，若未设置 `CONTAINER_HOST` 和 `XDG_RUNTIME_DIR` 且没有运行 Podman machine，
+Podman 会回退至 `$TMPDIR/storage-run-$(id -u)/podman/podman.sock`
+（[源码](https://github.com/containers/storage/blob/main/pkg/homedir/homedir_unix.go)）。
+macOS 上的 `$TMPDIR` 解析为 `/var/folders/…/<hash>/T/`，这是每用户的稳定路径，
+**重启后不会丢失**。创建目录并将 Mocker 的 socket 软链至此处：
+
+```bash
+# 将 Podman 默认 socket 指向 Mocker（macOS）
+PODMAN_SOCK_DIR="${TMPDIR%/}/storage-run-$(id -u)/podman"
+mkdir -p "$PODMAN_SOCK_DIR"
+ln -sf "$HOME/.mocker/mocker.sock" "$PODMAN_SOCK_DIR/podman.sock"
+
+# 无需环境变量即可使用
+podman version
+podman ps
+```
+
+撤销：
+```bash
+rm "${TMPDIR%/}/storage-run-$(id -u)/podman/podman.sock"
+```
+
 #### 通过 launchd 自动启动（macOS）
 
 如需在登录时自动启动 socket 服务并在后台保持运行，可将其注册为 launchd 用户代理。

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -348,9 +348,7 @@ podman run --rm alpine cat /etc/os-release
     </dict>
   </dict>
   <key>RunAtLoad</key>
-  <true/>
-  <key>KeepAlive</key>
-  <true/>
+  <false/>
 </dict>
 </plist>
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -171,9 +171,45 @@ mocker rmi my-registry.io/alpine:v1
 # 从 Dockerfile 构建
 mocker build -t myapp:latest .
 
+# 指定架构构建
+mocker build --platform linux/amd64 -t myapp:amd64 .
+mocker build --platform linux/arm64 -t myapp:arm64 .
+
 # 推送到镜像仓库
 mocker push my-registry.io/myapp:latest
 ```
+
+#### 构建架构支持情况
+
+| 架构 | `mocker build` | `mocker run` | 说明 |
+|---|:---:|:---:|---|
+| `linux/arm64` | ✅ | ✅ | 原生 — Apple Silicon |
+| `linux/amd64` | ✅ | ✅ | 通过 Rosetta 2 硬件转译 |
+| `linux/ppc64le` | ⚠️ | ❌ | 无 `RUN` 步骤时可构建；`RUN` 会报 Exec format error |
+| `linux/s390x` | ⚠️ | ❌ | 与 ppc64le 限制相同 |
+| `linux/riscv64` | ⚠️ | ❌ | 与 ppc64le 限制相同 |
+
+`linux/amd64` 之所以无缝支持，是因为 Apple Silicon 内置了 Rosetta 2（x86 硬件转译）。对于其他非原生架构（ppc64le、s390x、riscv64），仅含 `FROM`/`COPY`/`CMD` 的 Dockerfile 可以成功构建（直接复用多架构基础镜像的对应层），但任何 `RUN` 指令都会因 Apple 构建 VM 未注册 QEMU 用户态模拟而报 `Exec format error`。
+
+作为对比，macOS 上的 Podman machine 可通过其 Fedora CoreOS VM 内置的 QEMU 处理 ppc64le/s390x 的 `RUN` 步骤——代价是需要维护一个持久的共享虚拟机。
+
+**针对异构架构 `RUN` 步骤的替代方案：**
+
+```bash
+# 方案一：远程构建器（配置了 QEMU binfmt 的 Linux 机器）
+docker buildx create --driver docker-container \
+  --platform linux/ppc64le,linux/s390x \
+  ssh://user@your-linux-box
+docker buildx build --platform linux/ppc64le -t myimage:ppc64le .
+
+# 方案二：GitHub Actions（无需额外基础设施）
+# 在 CI 中使用 docker/setup-qemu-action + docker/setup-buildx-action
+
+# 方案三：复用已运行的 Podman machine（已内置 QEMU）
+# 跟踪进展请见 us/mocker#10
+```
+
+> **进度追踪：** 异构架构构建支持正在 [us/mocker#10](https://github.com/us/mocker/issues/10) 及上游 [apple/container#1496](https://github.com/apple/container/issues/1496) 中跟踪。
 
 ### 检查与统计
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -37,6 +37,11 @@ mocker exec -it my-app sh
 
 ## 最新更新
 
+### v0.2.2 — 多架构构建 & 异构架构提示
+- **`mocker build --platform linux/arm64,linux/amd64,linux/ppc64le -t myimage .`** — 通过 Podman machine 实现多架构 manifest 构建（一条命令，所有架构）
+- 异构架构警告：`mocker build --platform linux/ppc64le` 现在在失败前后打印可操作的提示，而非仅输出退出码错误
+- 自动检测 Podman machine 是否运行；未运行时输出分步恢复说明
+
 ### v0.2.1 — 嵌套虚拟化
 - **`--virtualization` / `--kernel`** 适用于 `mocker run` 和 `mocker create` — 向容器暴露嵌套虚拟化能力（closes #4）
 
@@ -181,35 +186,63 @@ mocker push my-registry.io/myapp:latest
 
 #### 构建架构支持情况
 
-| 架构 | `mocker build` | `mocker run` | 说明 |
-|---|:---:|:---:|---|
-| `linux/arm64` | ✅ | ✅ | 原生 — Apple Silicon |
-| `linux/amd64` | ✅ | ✅ | 通过 Rosetta 2 硬件转译 |
-| `linux/ppc64le` | ⚠️ | ❌ | 无 `RUN` 步骤时可构建；`RUN` 会报 Exec format error |
-| `linux/s390x` | ⚠️ | ❌ | 与 ppc64le 限制相同 |
-| `linux/riscv64` | ⚠️ | ❌ | 与 ppc64le 限制相同 |
+| 架构 | `mocker build`（单架构） | `mocker build`（多架构） | `mocker run` | 说明 |
+|---|:---:|:---:|:---:|---|
+| `linux/arm64` | ✅ | ✅ | ✅ | 原生 — Apple Silicon |
+| `linux/amd64` | ✅ | ✅ | ✅ | 通过 Rosetta 2 硬件转译 |
+| `linux/ppc64le` | ⚠️ | ✅* | ❌ | 单架构：`RUN` 失败；多架构：通过 Podman machine QEMU |
+| `linux/s390x` | ⚠️ | ✅* | ❌ | 与 ppc64le 相同 |
+| `linux/riscv64` | ⚠️ | ✅* | ❌ | 与 ppc64le 相同 |
+
+\* 异构架构的多架构构建需要运行中的 Podman machine（`podman machine start`）。
 
 `linux/amd64` 之所以无缝支持，是因为 Apple Silicon 内置了 Rosetta 2（x86 硬件转译）。对于其他非原生架构（ppc64le、s390x、riscv64），仅含 `FROM`/`COPY`/`CMD` 的 Dockerfile 可以成功构建（直接复用多架构基础镜像的对应层），但任何 `RUN` 指令都会因 Apple 构建 VM 未注册 QEMU 用户态模拟而报 `Exec format error`。
 
 作为对比，macOS 上的 Podman machine 可通过其 Fedora CoreOS VM 内置的 QEMU 处理 ppc64le/s390x 的 `RUN` 步骤——代价是需要维护一个持久的共享虚拟机。
 
-**针对异构架构 `RUN` 步骤的替代方案：**
+#### 多架构 Manifest 构建
+
+`mocker build` 支持逗号分隔的 `--platform` 列表。指定多个平台时，将通过 Podman（其 Fedora CoreOS VM 内含 QEMU）分别构建每个架构，并使用 `podman manifest create` 组装 OCI manifest list：
 
 ```bash
-# 方案一：远程构建器（配置了 QEMU binfmt 的 Linux 机器）
+# 构建多架构 manifest 镜像（arm64 + amd64 + ppc64le）
+# 前提：podman machine start
+mocker build \
+  --platform linux/arm64,linux/amd64,linux/ppc64le \
+  -t myimage:latest \
+  .
+
+# 构建结果：
+#   myimage:latest-arm64   (linux/arm64)
+#   myimage:latest-amd64   (linux/amd64)
+#   myimage:latest-ppc64le (linux/ppc64le)
+#   myimage:latest         (manifest list → 包含以上三个)
+```
+
+对于单架构的异构平台构建，mocker 会在尝试构建前后输出带有可操作建议的警告信息。
+
+**针对异构架构 `RUN` 步骤的替代方案（单架构）：**
+
+```bash
+# 方案一：mocker 多架构构建（需要 Podman machine）
+podman machine start
+mocker build --platform linux/arm64,linux/ppc64le -t myimage .
+
+# 方案二：直接使用 Podman
+podman machine start
+podman build --platform linux/ppc64le -t myimage:ppc64le .
+
+# 方案三：远程构建器（配置了 QEMU binfmt 的 Linux 机器）
 docker buildx create --driver docker-container \
   --platform linux/ppc64le,linux/s390x \
   ssh://user@your-linux-box
 docker buildx build --platform linux/ppc64le -t myimage:ppc64le .
 
-# 方案二：GitHub Actions（无需额外基础设施）
+# 方案四：GitHub Actions（无需额外基础设施）
 # 在 CI 中使用 docker/setup-qemu-action + docker/setup-buildx-action
-
-# 方案三：复用已运行的 Podman machine（已内置 QEMU）
-# 跟踪进展请见 us/mocker#10
 ```
 
-> **进度追踪：** 异构架构构建支持正在 [us/mocker#10](https://github.com/us/mocker/issues/10) 及上游 [apple/container#1496](https://github.com/apple/container/issues/1496) 中跟踪。
+> **进度追踪：** 异构架构构建支持正在 [us/mocker#10](https://github.com/us/mocker/issues/10) 及上游 [apple/container#1496](https://github.com/apple/container/issues/1496) 中跟踪。Manifest 组装方案（无需 Apple `container manifest`）正在 [us/mocker#11](https://github.com/us/mocker/issues/11) 中跟踪。
 
 ### 检查与统计
 

--- a/Sources/Mocker/Commands/Build.swift
+++ b/Sources/Mocker/Commands/Build.swift
@@ -1,4 +1,5 @@
 import ArgumentParser
+import Foundation
 import MockerKit
 
 struct Build: AsyncParsableCommand {
@@ -122,8 +123,17 @@ struct Build: AsyncParsableCommand {
     func run() async throws {
         let config = MockerConfig()
         try config.ensureDirectories()
-        let manager = try ImageManager(config: config)
 
+        // Multi-arch build: comma-separated platforms
+        if let platformStr = platform, platformStr.contains(",") {
+            let platforms = platformStr.split(separator: ",")
+                .map { $0.trimmingCharacters(in: .whitespaces) }
+                .filter { !$0.isEmpty }
+            try await runMultiArchBuild(platforms: platforms)
+            return
+        }
+
+        let manager = try ImageManager(config: config)
         if !quiet {
             print("Building \(tag)...")
         }
@@ -139,4 +149,131 @@ struct Build: AsyncParsableCommand {
             print("Successfully tagged \(tag)")
         }
     }
+
+    // MARK: - Multi-arch build via Podman
+
+    private func runMultiArchBuild(platforms: [String]) async throws {
+        let nativePlatforms: Set<String> = ["linux/arm64", "linux/arm64/v8", "linux/amd64", "linux/x86_64"]
+        let exoticPlatforms = platforms.filter { !nativePlatforms.contains($0) }
+
+        print("Multi-arch build: \(platforms.joined(separator: ", "))")
+        if !exoticPlatforms.isEmpty {
+            print("Note: Exotic arches (\(exoticPlatforms.joined(separator: ", "))) require QEMU via Podman machine.")
+        }
+        print("Using Podman for all architectures to enable manifest assembly.\n")
+
+        guard await checkPodmanMachineRunning() else {
+            var hint = "No running Podman machine found. Start one with:\n"
+            hint += "  podman machine start\n\n"
+            let native = platforms.filter { nativePlatforms.contains($0) }
+            if !native.isEmpty {
+                hint += "You can build native arches individually without Podman:\n"
+                for arch in native {
+                    hint += "  mocker build --platform \(arch) -t \(tag) \(context)\n"
+                }
+            }
+            FileHandle.standardError.write(Data(hint.utf8))
+            throw MockerError.buildError("Multi-arch build requires a running Podman machine with QEMU support")
+        }
+
+        let baseTag = tag.contains(":") ? tag : "\(tag):latest"
+        let colonIdx = baseTag.firstIndex(of: ":")!
+        let imageName = String(baseTag[baseTag.startIndex..<colonIdx])
+        let imageVersion = String(baseTag[baseTag.index(after: colonIdx)...])
+
+        var archTags: [String] = []
+        for arch in platforms {
+            let slug = platformSlug(arch)
+            let archTag = "\(imageName):\(imageVersion)-\(slug)"
+            archTags.append(archTag)
+            print("Building [\(arch)] → \(archTag)")
+            try await runPodmanBuild(platform: arch, tag: archTag)
+            print("")
+        }
+
+        print("Assembling manifest: \(tag)")
+        try await runPodmanManifestCreate(manifestTag: tag, imageTags: archTags)
+
+        print("\nSuccessfully built multi-arch image: \(tag)")
+        print("Platforms: \(platforms.joined(separator: ", "))")
+        print("Arch-specific images:")
+        for (arch, archTag) in zip(platforms, archTags) {
+            print("  \(arch) → \(archTag)")
+        }
+    }
+
+    private func checkPodmanMachineRunning() async -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["podman", "machine", "list", "--format", "{{.Running}}"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        process.standardError = Pipe()
+        guard (try? process.run()) != nil else { return false }
+        let exitCode = await withCheckedContinuation { (continuation: CheckedContinuation<Int32, Never>) in
+            process.terminationHandler = { p in continuation.resume(returning: p.terminationStatus) }
+        }
+        guard exitCode == 0 else { return false }
+        let output = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        return output.components(separatedBy: "\n").map { $0.trimmingCharacters(in: .whitespaces) }.contains("true")
+    }
+
+    private func runPodmanBuild(platform: String, tag: String) async throws {
+        let contextURL = context.hasPrefix("/")
+            ? URL(fileURLWithPath: context)
+            : URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+                .appendingPathComponent(context).standardized
+        let dockerfilePath = contextURL.appendingPathComponent(file).path
+
+        var args = ["build", "--platform", platform, "-t", tag, "-f", dockerfilePath]
+        if noCache { args.append("--no-cache") }
+        for arg in buildArg { args += ["--build-arg", arg] }
+        if let t = target { args += ["--target", t] }
+        for l in label { args += ["-l", l] }
+        args.append(contextURL.path)
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["podman"] + args
+        process.standardOutput = FileHandle.standardOutput
+        process.standardError = FileHandle.standardError
+        try process.run()
+        let exitCode = await withCheckedContinuation { (continuation: CheckedContinuation<Int32, Never>) in
+            process.terminationHandler = { p in continuation.resume(returning: p.terminationStatus) }
+        }
+        guard exitCode == 0 else {
+            throw MockerError.buildError("podman build failed for \(platform) (exit \(exitCode))")
+        }
+    }
+
+    private func runPodmanManifestCreate(manifestTag: String, imageTags: [String]) async throws {
+        // Remove existing manifest first (ignore errors)
+        let rmProcess = Process()
+        rmProcess.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        rmProcess.arguments = ["podman", "manifest", "rm", manifestTag]
+        rmProcess.standardOutput = Pipe()
+        rmProcess.standardError = Pipe()
+        try? rmProcess.run()
+        rmProcess.waitUntilExit()
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["podman", "manifest", "create", manifestTag] + imageTags
+        process.standardOutput = FileHandle.standardOutput
+        process.standardError = FileHandle.standardError
+        try process.run()
+        let exitCode = await withCheckedContinuation { (continuation: CheckedContinuation<Int32, Never>) in
+            process.terminationHandler = { p in continuation.resume(returning: p.terminationStatus) }
+        }
+        guard exitCode == 0 else {
+            throw MockerError.buildError("podman manifest create failed (exit \(exitCode))")
+        }
+    }
+
+    private func platformSlug(_ platform: String) -> String {
+        // linux/arm64/v8 → arm64v8, linux/ppc64le → ppc64le
+        let parts = platform.split(separator: "/").dropFirst()
+        return parts.joined()
+    }
 }
+

--- a/Sources/Mocker/Commands/Socket.swift
+++ b/Sources/Mocker/Commands/Socket.swift
@@ -1,0 +1,213 @@
+import ArgumentParser
+import Foundation
+import MockerKit
+
+struct SocketCommand: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "socket",
+        abstract: "Manage the Mocker Docker-compatible Unix socket",
+        subcommands: [
+            SocketInstall.self,
+            SocketUninstall.self,
+            SocketStatus.self,
+        ]
+    )
+}
+
+// MARK: - mocker socket install
+
+struct SocketInstall: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "install",
+        abstract: "Install and activate the launchd socket agent"
+    )
+
+    @Option(name: .long, help: "Custom socket path (default: ~/.mocker/mocker.sock)")
+    var socketPath: String?
+
+    func run() async throws {
+        let config = MockerConfig()
+        let sock = socketPath ?? config.socketPath
+        let plistPath = config.launchAgentPlistPath
+        let binaryPath = resolveBinaryPath()
+
+        // Ensure ~/.mocker directory exists
+        try config.ensureDirectories()
+
+        // Write plist
+        let plistContent = buildPlist(binaryPath: binaryPath, socketPath: sock)
+        let plistURL = URL(fileURLWithPath: plistPath)
+        try FileManager.default.createDirectory(
+            at: plistURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try plistContent.write(to: plistURL, atomically: true, encoding: .utf8)
+
+        // Bootstrap the launchd agent
+        let uid = getuid()
+        let (_, exitCode) = try await runProcess(
+            "/bin/launchctl",
+            ["bootstrap", "gui/\(uid)", plistPath]
+        )
+
+        if exitCode == 0 {
+            print("Mocker socket agent installed.")
+            print("Socket path: \(sock)")
+            print("Set DOCKER_HOST=unix://\(sock) to use it with Docker-compatible tools.")
+        } else {
+            // Already loaded — try to unload and reload
+            _ = try? await runProcess("/bin/launchctl", ["bootout", "gui/\(uid)", MockerConfig.launchAgentLabel])
+            let (_, rc2) = try await runProcess(
+                "/bin/launchctl",
+                ["bootstrap", "gui/\(uid)", plistPath]
+            )
+            if rc2 == 0 {
+                print("Mocker socket agent reinstalled.")
+                print("Socket path: \(sock)")
+            } else {
+                print("Warning: launchctl bootstrap returned exit code \(rc2).")
+                print("Plist written to: \(plistPath)")
+                print("Run manually: launchctl bootstrap gui/\(uid) \(plistPath)")
+            }
+        }
+    }
+
+    private func buildPlist(binaryPath: String, socketPath: String) -> String {
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+            <key>Label</key>
+            <string>io.mocker.socket</string>
+            <key>ProgramArguments</key>
+            <array>
+                <string>\(binaryPath)</string>
+                <string>system</string>
+                <string>service</string>
+                <string>--timeout</string>
+                <string>5s</string>
+            </array>
+            <key>Sockets</key>
+            <dict>
+                <key>MockerSocket</key>
+                <dict>
+                    <key>SockPathName</key>
+                    <string>\(socketPath)</string>
+                </dict>
+            </dict>
+            <key>RunAtLoad</key>
+            <false/>
+        </dict>
+        </plist>
+        """
+    }
+
+    private func resolveBinaryPath() -> String {
+        // Use the path of the currently running mocker binary
+        let arg0 = ProcessInfo.processInfo.arguments[0]
+        if arg0.hasPrefix("/") { return arg0 }
+        // Try to resolve relative path
+        let cwd = FileManager.default.currentDirectoryPath
+        let resolved = (cwd as NSString).appendingPathComponent(arg0)
+        if FileManager.default.isExecutableFile(atPath: resolved) { return resolved }
+        // Fallback
+        return "/usr/local/bin/mocker"
+    }
+}
+
+// MARK: - mocker socket uninstall
+
+struct SocketUninstall: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "uninstall",
+        abstract: "Deactivate and remove the launchd socket agent"
+    )
+
+    func run() async throws {
+        let config = MockerConfig()
+        let uid = getuid()
+        let label = MockerConfig.launchAgentLabel
+
+        // Bootout
+        let (_, exitCode) = try await runProcess(
+            "/bin/launchctl",
+            ["bootout", "gui/\(uid)", label]
+        )
+
+        // Remove plist file
+        let plistPath = config.launchAgentPlistPath
+        if FileManager.default.fileExists(atPath: plistPath) {
+            try? FileManager.default.removeItem(atPath: plistPath)
+        }
+
+        // Remove socket file if present
+        let sock = config.socketPath
+        if FileManager.default.fileExists(atPath: sock) {
+            try? FileManager.default.removeItem(atPath: sock)
+        }
+
+        if exitCode == 0 {
+            print("Mocker socket agent uninstalled.")
+        } else {
+            print("Mocker socket agent removed (was not loaded or already removed).")
+        }
+    }
+}
+
+// MARK: - mocker socket status
+
+struct SocketStatus: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "status",
+        abstract: "Show the status of the launchd socket agent"
+    )
+
+    func run() async throws {
+        let config = MockerConfig()
+        let sock = config.socketPath
+        let plistPath = config.launchAgentPlistPath
+        let label = MockerConfig.launchAgentLabel
+
+        let plistExists = FileManager.default.fileExists(atPath: plistPath)
+        let sockExists = FileManager.default.fileExists(atPath: sock)
+
+        print("Label:       \(label)")
+        print("Plist:       \(plistPath) [\(plistExists ? "installed" : "not installed")]")
+        print("Socket:      \(sock) [\(sockExists ? "exists" : "not present")]")
+        print("DOCKER_HOST: unix://\(sock)")
+
+        // Check launchd status
+        let (output, exitCode) = try await runProcess(
+            "/bin/launchctl",
+            ["list", label]
+        )
+        if exitCode == 0 {
+            print("Agent:       loaded")
+            if !output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                print(output.trimmingCharacters(in: .whitespacesAndNewlines))
+            }
+        } else {
+            print("Agent:       not loaded")
+        }
+    }
+}
+
+// MARK: - Helpers
+
+private func runProcess(_ path: String, _ args: [String]) async throws -> (String, Int32) {
+    let p = Process()
+    p.executableURL = URL(fileURLWithPath: path)
+    p.arguments = args
+    let pipe = Pipe()
+    p.standardOutput = pipe
+    p.standardError = pipe
+    try p.run()
+    return await withCheckedContinuation { continuation in
+        p.terminationHandler = { proc in
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            let out = String(data: data, encoding: .utf8) ?? ""
+            continuation.resume(returning: (out, proc.terminationStatus))
+        }
+    }
+}

--- a/Sources/Mocker/Commands/System.swift
+++ b/Sources/Mocker/Commands/System.swift
@@ -1,4 +1,9 @@
 import ArgumentParser
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
 import Foundation
 import MockerKit
 
@@ -11,8 +16,50 @@ struct SystemCommand: AsyncParsableCommand {
             SystemPrune.self,
             SystemDf.self,
             SystemEvents.self,
+            SystemService.self,
         ]
     )
+}
+
+// MARK: - mocker system service
+
+struct SystemService: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "service",
+        abstract: "Run the Docker-compatible REST API server over a Unix socket"
+    )
+
+    @Option(name: .long, help: "Inactivity timeout before exiting (e.g. 5s, 30s, 5m). Omit for no timeout.")
+    var timeout: String?
+
+    @Option(name: .long, help: "Socket path to listen on (ignored when activated by launchd)")
+    var socketPath: String?
+
+    func run() async throws {
+        let config = MockerConfig()
+        try config.ensureDirectories()
+
+        let timeoutInterval = timeout.flatMap(parseTimeout)
+        let server = try DockerAPIServer(config: config, timeout: timeoutInterval)
+
+        // Try launchd socket activation first
+        if let fd = launchdActivateSocket(name: "MockerSocket") {
+            try await server.serve(serverFd: fd)
+        } else {
+            // Standalone mode: create socket at configured path
+            let sock = socketPath ?? config.socketPath
+            fputs("Listening on unix://\(sock)\n", Darwin.stderr)
+            try await server.serve(socketPath: sock)
+        }
+    }
+
+    /// Parse a duration string such as "5s", "30s", "5m", "1h" into seconds.
+    private func parseTimeout(_ s: String) -> TimeInterval? {
+        if s.hasSuffix("s"), let n = Double(s.dropLast()) { return n }
+        if s.hasSuffix("m"), let n = Double(s.dropLast()) { return n * 60 }
+        if s.hasSuffix("h"), let n = Double(s.dropLast()) { return n * 3600 }
+        return Double(s) // plain number treated as seconds
+    }
 }
 
 struct SystemInfo: AsyncParsableCommand {

--- a/Sources/Mocker/Commands/System.swift
+++ b/Sources/Mocker/Commands/System.swift
@@ -1,9 +1,4 @@
 import ArgumentParser
-#if canImport(Darwin)
-import Darwin
-#else
-import Glibc
-#endif
 import Foundation
 import MockerKit
 
@@ -48,7 +43,7 @@ struct SystemService: AsyncParsableCommand {
         } else {
             // Standalone mode: create socket at configured path
             let sock = socketPath ?? config.socketPath
-            fputs("Listening on unix://\(sock)\n", Darwin.stderr)
+            FileHandle.standardError.write(Data("Listening on unix://\(sock)\n".utf8))
             try await server.serve(socketPath: sock)
         }
     }

--- a/Sources/Mocker/MockerCLI.swift
+++ b/Sources/Mocker/MockerCLI.swift
@@ -52,6 +52,7 @@ struct MockerCLI: AsyncParsableCommand {
             ComposeCommand.self,
             SystemCommand.self,
             Proxy.self,
+            SocketCommand.self,
         ]
     )
 }

--- a/Sources/MockerKit/Config/MockerConfig.swift
+++ b/Sources/MockerKit/Config/MockerConfig.swift
@@ -67,6 +67,21 @@ public struct MockerConfig: Codable, Sendable {
     /// Directory for port proxy PID files.
     public var proxiesPath: String { "\(dataRoot)/proxies" }
 
+    /// Unix domain socket path served by `mocker system service`.
+    public var socketPath: String { "\(dataRoot)/mocker.sock" }
+
+    /// Path for the launchd user-agent plist that enables socket activation.
+    public var launchAgentPlistPath: String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return "\(home)/Library/LaunchAgents/io.mocker.socket.plist"
+    }
+
+    /// Label used for the launchd agent.
+    public static let launchAgentLabel = "io.mocker.socket"
+
+    /// Mocker version string, kept in sync with Version.currentVersion in the CLI target.
+    public static let mockerVersion = "0.2.0"
+
     /// Ensure all required directories exist.
     public func ensureDirectories() throws {
         let fm = FileManager.default

--- a/Sources/MockerKit/Container/ContainerEngine.swift
+++ b/Sources/MockerKit/Container/ContainerEngine.swift
@@ -64,26 +64,12 @@ public actor ContainerEngine {
 
         try process.run()
 
+        // Read both pipes serially inside terminationHandler (after process exit, no concurrency issue).
         return await withCheckedContinuation { continuation in
-            let group = DispatchGroup()
-            var outData = Data()
-            var errData = Data()
-
-            group.enter()
-            DispatchQueue.global().async {
-                outData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-                group.leave()
-            }
-            group.enter()
-            DispatchQueue.global().async {
-                errData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-                group.leave()
-            }
-
             process.terminationHandler = { p in
-                group.notify(queue: .global()) {
-                    continuation.resume(returning: (stdout: outData, stderr: errData, exitCode: p.terminationStatus))
-                }
+                let outData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+                let errData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+                continuation.resume(returning: (stdout: outData, stderr: errData, exitCode: p.terminationStatus))
             }
         }
     }

--- a/Sources/MockerKit/Container/ContainerEngine.swift
+++ b/Sources/MockerKit/Container/ContainerEngine.swift
@@ -43,11 +43,14 @@ public actor ContainerEngine {
 
     // MARK: - Run (attach / output-capture)
 
-    /// Run a container **without** `-d` (detach) and capture its stdout + stderr as raw `Data`.
+    /// Run a container and stream its stdout/stderr to `onOutput` as data arrives.
     ///
-    /// Used by the Docker-socket attach handler so that `docker run` and `podman run`
-    /// can stream the container's output back over the HTTP-101 hijacked connection.
-    public func runWithOutputCapture(_ config: ContainerConfig) async throws -> (stdout: Data, stderr: Data, exitCode: Int32) {
+    /// `onOutput` is called from a serial queue so concurrent stdout/stderr reads
+    /// never race on the caller's write side (e.g. a raw socket fd).
+    public func runStreaming(
+        _ config: ContainerConfig,
+        onOutput: @Sendable @escaping (_ type: UInt8, _ data: Data) -> Void
+    ) async throws -> Int32 {
         var args = ["run"]
         if config.rm { args.append("--rm") }
         args.append(config.image)
@@ -64,33 +67,41 @@ public actor ContainerEngine {
 
         try process.run()
 
-        // Drain both pipes concurrently while the process runs to avoid blocking on a full
-        // pipe buffer (~64 KB), which would otherwise deadlock before the process can exit.
         return await withCheckedContinuation { continuation in
-            // Use a reference type so concurrent closures can write without triggering
-            // Swift's SendableClosureCaptures diagnostic on captured `var`.
-            final class Box: @unchecked Sendable { var data = Data() }
-            let outBox = Box()
-            let errBox = Box()
+            let serial = DispatchQueue(label: "mocker.stream.frame")
             let group = DispatchGroup()
 
-            group.enter()
-            DispatchQueue.global(qos: .userInitiated).async {
-                outBox.data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-                group.leave()
+            func drain(handle: FileHandle, type: UInt8) {
+                group.enter()
+                DispatchQueue.global(qos: .userInitiated).async {
+                    while true {
+                        let chunk = handle.availableData
+                        if chunk.isEmpty { break }
+                        serial.sync { onOutput(type, chunk) }
+                    }
+                    group.leave()
+                }
             }
 
-            group.enter()
-            DispatchQueue.global(qos: .userInitiated).async {
-                errBox.data = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-                group.leave()
-            }
+            drain(handle: stdoutPipe.fileHandleForReading, type: 1)
+            drain(handle: stderrPipe.fileHandleForReading, type: 2)
 
             group.notify(queue: .global(qos: .userInitiated)) {
                 process.waitUntilExit()
-                continuation.resume(returning: (stdout: outBox.data, stderr: errBox.data, exitCode: process.terminationStatus))
+                continuation.resume(returning: process.terminationStatus)
             }
         }
+    }
+
+    /// Run a container **without** `-d` (detach) and capture its stdout + stderr as raw `Data`.
+    public func runWithOutputCapture(_ config: ContainerConfig) async throws -> (stdout: Data, stderr: Data, exitCode: Int32) {
+        final class Box: @unchecked Sendable { var data = Data() }
+        let outBox = Box()
+        let errBox = Box()
+        let exitCode = try await runStreaming(config) { type, chunk in
+            if type == 1 { outBox.data.append(chunk) } else { errBox.data.append(chunk) }
+        }
+        return (stdout: outBox.data, stderr: errBox.data, exitCode: exitCode)
     }
 
     // MARK: - Run

--- a/Sources/MockerKit/Container/ContainerEngine.swift
+++ b/Sources/MockerKit/Container/ContainerEngine.swift
@@ -41,6 +41,53 @@ public actor ContainerEngine {
         )
     }
 
+    // MARK: - Run (attach / output-capture)
+
+    /// Run a container **without** `-d` (detach) and capture its stdout + stderr as raw `Data`.
+    ///
+    /// Used by the Docker-socket attach handler so that `docker run` and `podman run`
+    /// can stream the container's output back over the HTTP-101 hijacked connection.
+    public func runWithOutputCapture(_ config: ContainerConfig) async throws -> (stdout: Data, stderr: Data, exitCode: Int32) {
+        var args = ["run"]
+        if config.rm { args.append("--rm") }
+        args.append(config.image)
+        args += config.command
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: Self.containerCLI)
+        process.arguments = args
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        try process.run()
+
+        return await withCheckedContinuation { continuation in
+            let group = DispatchGroup()
+            var outData = Data()
+            var errData = Data()
+
+            group.enter()
+            DispatchQueue.global().async {
+                outData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+                group.leave()
+            }
+            group.enter()
+            DispatchQueue.global().async {
+                errData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+                group.leave()
+            }
+
+            process.terminationHandler = { p in
+                group.notify(queue: .global()) {
+                    continuation.resume(returning: (stdout: outData, stderr: errData, exitCode: p.terminationStatus))
+                }
+            }
+        }
+    }
+
     // MARK: - Run
 
     public func run(_ containerConfig: ContainerConfig) async throws -> ContainerInfo {

--- a/Sources/MockerKit/Container/ContainerEngine.swift
+++ b/Sources/MockerKit/Container/ContainerEngine.swift
@@ -64,12 +64,31 @@ public actor ContainerEngine {
 
         try process.run()
 
-        // Read both pipes serially inside terminationHandler (after process exit, no concurrency issue).
+        // Drain both pipes concurrently while the process runs to avoid blocking on a full
+        // pipe buffer (~64 KB), which would otherwise deadlock before the process can exit.
         return await withCheckedContinuation { continuation in
-            process.terminationHandler = { p in
-                let outData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-                let errData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
-                continuation.resume(returning: (stdout: outData, stderr: errData, exitCode: p.terminationStatus))
+            // Use a reference type so concurrent closures can write without triggering
+            // Swift's SendableClosureCaptures diagnostic on captured `var`.
+            final class Box: @unchecked Sendable { var data = Data() }
+            let outBox = Box()
+            let errBox = Box()
+            let group = DispatchGroup()
+
+            group.enter()
+            DispatchQueue.global(qos: .userInitiated).async {
+                outBox.data = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+                group.leave()
+            }
+
+            group.enter()
+            DispatchQueue.global(qos: .userInitiated).async {
+                errBox.data = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+                group.leave()
+            }
+
+            group.notify(queue: .global(qos: .userInitiated)) {
+                process.waitUntilExit()
+                continuation.resume(returning: (stdout: outBox.data, stderr: errBox.data, exitCode: process.terminationStatus))
             }
         }
     }

--- a/Sources/MockerKit/Image/ImageManager.swift
+++ b/Sources/MockerKit/Image/ImageManager.swift
@@ -110,6 +110,14 @@ public actor ImageManager {
 
     private static let containerCLI = "/usr/local/bin/container"
 
+    private static let nativeArches: Set<String> = [
+        "linux/arm64", "linux/arm64/v8", "linux/amd64", "linux/x86_64",
+    ]
+
+    static func isExoticArch(_ platform: String) -> Bool {
+        !nativeArches.contains(platform)
+    }
+
     /// Build an image from a Dockerfile using the `container` CLI.
     public func build(tag: String, context: String, dockerfile: String = "Dockerfile", noCache: Bool = false, buildArgs: [String] = [], platform: String? = nil, target: String? = nil, labels: [String] = [], quiet: Bool = false, progress: String? = nil, output: [String] = []) async throws -> ImageInfo {
         let contextURL: URL
@@ -124,6 +132,20 @@ public actor ImageManager {
 
         guard FileManager.default.fileExists(atPath: dockerfilePath) else {
             throw MockerError.buildError("Dockerfile not found at \(dockerfilePath)")
+        }
+
+        if let platform, Self.isExoticArch(platform) {
+            let warning = """
+                Warning: \(platform) requires QEMU emulation, which Apple's container runtime does not support.
+                         Any RUN instruction will fail with 'Exec format error'.
+                         To build for this architecture, use a Podman machine (which includes QEMU):
+                           podman machine start
+                           podman build --platform \(platform) -t \(tag) \(context)
+                         Or use mocker's multi-arch build:
+                           mocker build --platform linux/arm64,\(platform) -t \(tag) .
+
+                """
+            FileHandle.standardError.write(Data(warning.utf8))
         }
 
         var args = ["build", "-t", tag, "-f", dockerfilePath]
@@ -153,6 +175,14 @@ public actor ImageManager {
         }
 
         guard exitCode == 0 else {
+            if let platform, Self.isExoticArch(platform) {
+                throw MockerError.buildError(
+                    "Build failed for \(platform) (exit \(exitCode)) — Apple's container runtime has no QEMU support for this architecture.\n" +
+                    "Use Podman machine instead:\n" +
+                    "  podman machine start\n" +
+                    "  podman build --platform \(platform) -t \(tag) \(context)"
+                )
+            }
             throw MockerError.buildError("Build failed with exit code \(exitCode)")
         }
 

--- a/Sources/MockerKit/SocketService/DockerAPIHandlers.swift
+++ b/Sources/MockerKit/SocketService/DockerAPIHandlers.swift
@@ -738,7 +738,9 @@ extension DockerAPIHandlers {
         id: String,
         libpod: Bool = false
     ) async -> HTTPResponse {
-        let exitCode = await runStore.waitForExit(id: id)
+        guard let exitCode = await runStore.waitForExit(id: id) else {
+            return .error(404, message: "No such container: \(id)")
+        }
         if libpod {
             struct LibpodWait: Encodable, Sendable {
                 struct WaitError: Encodable, Sendable { let Message: String }

--- a/Sources/MockerKit/SocketService/DockerAPIHandlers.swift
+++ b/Sources/MockerKit/SocketService/DockerAPIHandlers.swift
@@ -285,6 +285,32 @@ enum DockerAPIHandlers {
             return await inspectImage(imageManager: imageManager, name: name)
         }
 
+        // Podman libpod API – minimal subset so `podman version` and `podman ps` work
+        // when CONTAINER_HOST points at the mocker socket.
+        if path.hasPrefix("/libpod/") {
+            let subpath = String(path.dropFirst("/libpod".count)) // "/libpod/foo" → "/foo"
+            if method == "GET" && (subpath == "/_ping" || subpath == "/ping") {
+                return .text(200, body: "OK")
+            }
+            if method == "HEAD" && (subpath == "/_ping" || subpath == "/ping") {
+                return .text(200, body: "")
+            }
+            if method == "GET" && subpath == "/version" {
+                return libpodVersionResponse()
+            }
+            if method == "GET" && subpath == "/info" {
+                return await infoResponse(engine: engine, imageManager: imageManager)
+            }
+            if method == "GET" && subpath == "/containers/json" {
+                let all = request.queryItems["all"].map { $0 == "1" || $0 == "true" } ?? false
+                return await listContainers(engine: engine, all: all)
+            }
+            if method == "GET" && subpath == "/images/json" {
+                return await listImages(imageManager: imageManager)
+            }
+            return .error(404, message: "libpod endpoint not implemented: \(path)")
+        }
+
         return .error(404, message: "page not found")
     }
 

--- a/Sources/MockerKit/SocketService/DockerAPIHandlers.swift
+++ b/Sources/MockerKit/SocketService/DockerAPIHandlers.swift
@@ -720,11 +720,9 @@ extension DockerAPIHandlers {
         }
         return HTTPResponse.hijack { fd in
             do {
-                let (stdout, stderr, exitCode) = try await engine.runWithOutputCapture(config)
-                // stderr carries VM startup progress (e.g. [0/6] Fetching image), which
-                // happens before the container command runs, so emit it before stdout.
-                if !stderr.isEmpty { DockerAPIServer.writeDockerFrame(fd: fd, type: 2, data: stderr) }
-                if !stdout.isEmpty { DockerAPIServer.writeDockerFrame(fd: fd, type: 1, data: stdout) }
+                let exitCode = try await engine.runStreaming(config) { type, data in
+                    DockerAPIServer.writeDockerFrame(fd: fd, type: type, data: data)
+                }
                 await runStore.recordExit(id: id, code: exitCode)
             } catch {
                 let msg = Data("\(error)\n".utf8)

--- a/Sources/MockerKit/SocketService/DockerAPIHandlers.swift
+++ b/Sources/MockerKit/SocketService/DockerAPIHandlers.swift
@@ -1,0 +1,637 @@
+import Foundation
+
+// MARK: - Docker Engine API Response Types
+
+struct DockerVersionResponse: Encodable, Sendable {
+    let Platform: PlatformName
+    let Version: String
+    let ApiVersion: String
+    let MinAPIVersion: String
+    let GitCommit: String
+    let GoVersion: String
+    let Os: String
+    let Arch: String
+    let KernelVersion: String
+    let BuildTime: String
+
+    struct PlatformName: Encodable, Sendable { let Name: String }
+}
+
+struct DockerInfoResponse: Encodable, Sendable {
+    let ID: String
+    let Containers: Int
+    let ContainersRunning: Int
+    let ContainersPaused: Int
+    let ContainersStopped: Int
+    let Images: Int
+    let Driver: String
+    let ServerVersion: String
+    let OperatingSystem: String
+    let OSType: String
+    let Architecture: String
+    let NCPU: Int
+    let MemTotal: Int64
+    let DockerRootDir: String
+    let HttpProxy: String
+    let HttpsProxy: String
+    let NoProxy: String
+    let Name: String
+    let Labels: [String]
+    let ExperimentalBuild: Bool
+    let LiveRestoreEnabled: Bool
+}
+
+struct DockerContainerListItem: Encodable, Sendable {
+    let Id: String
+    let Names: [String]
+    let Image: String
+    let ImageID: String
+    let Command: String
+    let Created: Int64
+    let State: String
+    let Status: String
+    let Ports: [DockerPort]
+    let Labels: [String: String]
+    let NetworkSettings: DockerNetworkSettings
+    let Mounts: [DockerMount]
+    let HostConfig: DockerHostConfig
+}
+
+struct DockerPort: Encodable, Sendable {
+    let IP: String
+    let PrivatePort: Int
+    let PublicPort: Int
+    let proto: String
+
+    enum CodingKeys: String, CodingKey {
+        case IP, PrivatePort, PublicPort
+        case proto = "Type"
+    }
+}
+
+struct DockerNetworkSettings: Encodable, Sendable {
+    let Networks: [String: DockerNetwork]
+}
+
+struct DockerNetwork: Encodable, Sendable {
+    let IPAddress: String
+    let Gateway: String
+    let MacAddress: String
+}
+
+struct DockerMount: Encodable, Sendable {
+    let mountType: String
+    let Source: String
+    let Destination: String
+    let Mode: String
+    let RW: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case mountType = "Type"
+        case Source, Destination, Mode, RW
+    }
+}
+
+struct DockerHostConfig: Encodable, Sendable {
+    let NetworkMode: String
+}
+
+struct DockerContainerInspect: Encodable, Sendable {
+    let Id: String
+    let Created: String
+    let Path: String
+    let Args: [String]
+    let State: DockerContainerState
+    let Image: String
+    let Name: String
+    let Config: DockerContainerConfig
+    let HostConfig: DockerInspectHostConfig
+    let NetworkSettings: DockerInspectNetworkSettings
+    let Mounts: [DockerMount]
+}
+
+struct DockerContainerState: Encodable, Sendable {
+    let Status: String
+    let Running: Bool
+    let Paused: Bool
+    let Restarting: Bool
+    let Dead: Bool
+    let Pid: Int
+    let ExitCode: Int
+    let Error: String
+    let StartedAt: String
+    let FinishedAt: String
+}
+
+struct DockerContainerConfig: Encodable, Sendable {
+    let Hostname: String
+    let Image: String
+    let Labels: [String: String]
+    let Cmd: [String]
+    let Env: [String]
+    let WorkingDir: String
+    let Entrypoint: [String]?
+}
+
+struct DockerInspectHostConfig: Encodable, Sendable {
+    let Binds: [String]
+    let NetworkMode: String
+    let PortBindings: [String: [DockerPortBinding]]
+    let RestartPolicy: DockerRestartPolicy
+    let Memory: Int64
+    let CpuShares: Int
+}
+
+struct DockerPortBinding: Codable, Sendable {
+    let HostIp: String
+    let HostPort: String
+}
+
+struct DockerRestartPolicy: Encodable, Sendable {
+    let Name: String
+    let MaximumRetryCount: Int
+}
+
+struct DockerInspectNetworkSettings: Encodable, Sendable {
+    let IPAddress: String
+    let Networks: [String: DockerNetwork]
+}
+
+struct DockerImageListItem: Encodable, Sendable {
+    let Id: String
+    let RepoTags: [String]
+    let RepoDigests: [String]
+    let Created: Int64
+    let Size: Int64
+    let VirtualSize: Int64
+    let Labels: [String: String]
+}
+
+struct DockerImageInspect: Encodable, Sendable {
+    let Id: String
+    let RepoTags: [String]
+    let RepoDigests: [String]
+    let Created: String
+    let Size: Int64
+    let VirtualSize: Int64
+    let Labels: [String: String]
+    let Architecture: String
+    let Os: String
+    let Config: DockerImageConfig
+}
+
+struct DockerImageConfig: Encodable, Sendable {
+    let Cmd: [String]
+    let Entrypoint: [String]?
+    let Env: [String]
+    let WorkingDir: String
+    let Labels: [String: String]
+}
+
+struct DockerContainerCreateBody: Decodable, Sendable {
+    let Image: String
+    let Cmd: [String]?
+    let Env: [String]?
+    let Labels: [String: String]?
+    let WorkingDir: String?
+    let Entrypoint: [String]?
+    let User: String?
+    let HostConfig: CreateHostConfig?
+
+    struct CreateHostConfig: Decodable, Sendable {
+        let Binds: [String]?
+        let PortBindings: [String: [DockerPortBinding]]?
+        let Memory: Int64?
+        let CpuShares: Int?
+    }
+}
+
+// MARK: - Router
+
+enum DockerAPIHandlers {
+    static func route(
+        request: HTTPRequest,
+        engine: ContainerEngine,
+        imageManager: ImageManager
+    ) async -> HTTPResponse {
+        let path = request.strippedPath
+        let method = request.method
+
+        // Health check — Docker CLI hits this first, without a version prefix
+        if method == "GET" && (path == "/_ping" || path == "/ping") {
+            return .text(200, body: "OK")
+        }
+        if method == "HEAD" && (path == "/_ping" || path == "/ping") {
+            return .text(200, body: "")
+        }
+
+        // Version
+        if method == "GET" && path == "/version" {
+            return versionResponse()
+        }
+
+        // Info
+        if method == "GET" && path == "/info" {
+            return await infoResponse(engine: engine, imageManager: imageManager)
+        }
+
+        // Containers
+        if method == "GET" && path == "/containers/json" {
+            let all = request.queryItems["all"].map { $0 == "1" || $0 == "true" } ?? false
+            return await listContainers(engine: engine, all: all)
+        }
+
+        if method == "POST" && path == "/containers/create" {
+            let name = request.queryItems["name"]
+            return await createContainer(engine: engine, name: name, body: request.body)
+        }
+
+        if method == "GET" && path.hasPrefix("/containers/") && path.hasSuffix("/json") {
+            let id = midSegment(path, prefix: "/containers/", suffix: "/json")
+            return await inspectContainer(engine: engine, id: id)
+        }
+
+        if method == "POST" && path.hasPrefix("/containers/") && path.hasSuffix("/start") {
+            let id = midSegment(path, prefix: "/containers/", suffix: "/start")
+            return await startContainer(engine: engine, id: id)
+        }
+
+        if method == "POST" && path.hasPrefix("/containers/") && path.hasSuffix("/stop") {
+            let id = midSegment(path, prefix: "/containers/", suffix: "/stop")
+            return await stopContainer(engine: engine, id: id)
+        }
+
+        if method == "DELETE" && path.hasPrefix("/containers/") {
+            let id = String(path.dropFirst("/containers/".count))
+            let force = request.queryItems["force"].map { $0 == "1" || $0 == "true" } ?? false
+            return await removeContainer(engine: engine, id: id, force: force)
+        }
+
+        // Images
+        if method == "GET" && path == "/images/json" {
+            return await listImages(imageManager: imageManager)
+        }
+
+        if method == "POST" && path == "/images/create" {
+            let fromImage = request.queryItems["fromImage"] ?? ""
+            let tag = request.queryItems["tag"] ?? ""
+            let ref = tag.isEmpty || tag == "latest" ? fromImage : "\(fromImage):\(tag)"
+            return await pullImage(imageManager: imageManager, reference: ref)
+        }
+
+        if method == "GET" && path.hasPrefix("/images/") && path.hasSuffix("/json") {
+            let name = midSegment(path, prefix: "/images/", suffix: "/json")
+                .removingPercentEncoding ?? ""
+            return await inspectImage(imageManager: imageManager, name: name)
+        }
+
+        return .error(404, message: "page not found")
+    }
+
+    private static func midSegment(_ path: String, prefix: String, suffix: String) -> String {
+        var s = path
+        if s.hasPrefix(prefix) { s = String(s.dropFirst(prefix.count)) }
+        if s.hasSuffix(suffix) { s = String(s.dropLast(suffix.count)) }
+        return s
+    }
+}
+
+// MARK: - Handler Implementations
+
+extension DockerAPIHandlers {
+    static func versionResponse() -> HTTPResponse {
+        let ver = MockerConfig.mockerVersion
+        let arch: String = {
+            #if arch(arm64)
+            return "arm64"
+            #else
+            return "amd64"
+            #endif
+        }()
+        let response = DockerVersionResponse(
+            Platform: .init(Name: "Mocker Engine"),
+            Version: ver,
+            ApiVersion: DockerAPIServer.apiVersion,
+            MinAPIVersion: "1.24",
+            GitCommit: "mocker",
+            GoVersion: "swift",
+            Os: "linux",
+            Arch: arch,
+            KernelVersion: "Apple Containerization",
+            BuildTime: "2026-01-01T00:00:00.000000000+00:00"
+        )
+        return .json(body: response)
+    }
+
+    static func infoResponse(engine: ContainerEngine, imageManager: ImageManager) async -> HTTPResponse {
+        let containers = (try? await engine.list(all: true)) ?? []
+        let images = (try? await imageManager.list()) ?? []
+        let running = containers.filter { $0.state == .running }.count
+        let paused = containers.filter { $0.state == .paused }.count
+        let stopped = containers.count - running - paused
+        let info = ProcessInfo.processInfo
+        let arch: String = {
+            #if arch(arm64)
+            return "arm64"
+            #else
+            return "amd64"
+            #endif
+        }()
+        let response = DockerInfoResponse(
+            ID: "mocker-\(arch)",
+            Containers: containers.count,
+            ContainersRunning: running,
+            ContainersPaused: paused,
+            ContainersStopped: stopped,
+            Images: images.count,
+            Driver: "apple-containerization",
+            ServerVersion: MockerConfig.mockerVersion,
+            OperatingSystem: "macOS \(info.operatingSystemVersionString)",
+            OSType: "linux",
+            Architecture: arch,
+            NCPU: info.processorCount,
+            MemTotal: Int64(info.physicalMemory),
+            DockerRootDir: MockerConfig().dataRoot,
+            HttpProxy: "",
+            HttpsProxy: "",
+            NoProxy: "",
+            Name: Host.current().name ?? "localhost",
+            Labels: [],
+            ExperimentalBuild: false,
+            LiveRestoreEnabled: false
+        )
+        return .json(body: response)
+    }
+
+    static func listContainers(engine: ContainerEngine, all: Bool) async -> HTTPResponse {
+        let containers = (try? await engine.list(all: all)) ?? []
+        let items = containers.map { c -> DockerContainerListItem in
+            let ports = c.ports.map { p -> DockerPort in
+                DockerPort(
+                    IP: "0.0.0.0",
+                    PrivatePort: Int(p.containerPort),
+                    PublicPort: Int(p.hostPort),
+                    proto: p.portProtocol.rawValue
+                )
+            }
+            return DockerContainerListItem(
+                Id: c.id,
+                Names: ["/\(c.name)"],
+                Image: c.image,
+                ImageID: "sha256:\(c.id)",
+                Command: c.command.isEmpty ? "" : c.command,
+                Created: Int64(c.created.timeIntervalSince1970),
+                State: c.state.rawValue,
+                Status: c.status,
+                Ports: ports,
+                Labels: c.labels,
+                NetworkSettings: DockerNetworkSettings(
+                    Networks: [
+                        "bridge": DockerNetwork(
+                            IPAddress: c.networkAddress,
+                            Gateway: "",
+                            MacAddress: ""
+                        )
+                    ]
+                ),
+                Mounts: [],
+                HostConfig: DockerHostConfig(NetworkMode: "default")
+            )
+        }
+        return .json(body: items)
+    }
+
+    static func inspectContainer(engine: ContainerEngine, id: String) async -> HTTPResponse {
+        guard let c = try? await engine.inspect(id) else {
+            return .error(404, message: "No such container: \(id)")
+        }
+        let running = c.state == .running
+        let now = ISO8601DateFormatter().string(from: c.created)
+        let inspect = DockerContainerInspect(
+            Id: c.id,
+            Created: now,
+            Path: c.command.split(separator: " ").first.map(String.init) ?? "",
+            Args: c.command.split(separator: " ").dropFirst().map(String.init),
+            State: DockerContainerState(
+                Status: c.state.rawValue,
+                Running: running,
+                Paused: c.state == .paused,
+                Restarting: false,
+                Dead: c.state == .dead,
+                Pid: c.pid ?? 0,
+                ExitCode: 0,
+                Error: "",
+                StartedAt: running ? now : "0001-01-01T00:00:00Z",
+                FinishedAt: running ? "0001-01-01T00:00:00Z" : now
+            ),
+            Image: c.image,
+            Name: "/\(c.name)",
+            Config: DockerContainerConfig(
+                Hostname: c.name,
+                Image: c.image,
+                Labels: c.labels,
+                Cmd: c.command.isEmpty ? [] : c.command.split(separator: " ").map(String.init),
+                Env: [],
+                WorkingDir: "",
+                Entrypoint: nil
+            ),
+            HostConfig: DockerInspectHostConfig(
+                Binds: [],
+                NetworkMode: "default",
+                PortBindings: [:],
+                RestartPolicy: DockerRestartPolicy(Name: "no", MaximumRetryCount: 0),
+                Memory: 0,
+                CpuShares: 0
+            ),
+            NetworkSettings: DockerInspectNetworkSettings(
+                IPAddress: c.networkAddress,
+                Networks: [
+                    "bridge": DockerNetwork(
+                        IPAddress: c.networkAddress,
+                        Gateway: "",
+                        MacAddress: ""
+                    )
+                ]
+            ),
+            Mounts: []
+        )
+        return .json(body: inspect)
+    }
+
+    static func startContainer(engine: ContainerEngine, id: String) async -> HTTPResponse {
+        do {
+            _ = try await engine.start(id)
+            return .noContent()
+        } catch let error as MockerError {
+            if case .containerNotFound = error {
+                return .error(404, message: error.localizedDescription)
+            }
+            return .error(500, message: error.localizedDescription)
+        } catch {
+            return .error(500, message: "\(error)")
+        }
+    }
+
+    static func stopContainer(engine: ContainerEngine, id: String) async -> HTTPResponse {
+        do {
+            _ = try await engine.stop(id)
+            return .noContent()
+        } catch let error as MockerError {
+            if case .containerNotFound = error {
+                return .error(404, message: error.localizedDescription)
+            }
+            return .error(500, message: error.localizedDescription)
+        } catch {
+            return .error(500, message: "\(error)")
+        }
+    }
+
+    static func removeContainer(engine: ContainerEngine, id: String, force: Bool) async -> HTTPResponse {
+        do {
+            _ = try await engine.remove(id, force: force)
+            return .noContent()
+        } catch let error as MockerError {
+            if case .containerNotFound = error {
+                return .error(404, message: error.localizedDescription)
+            }
+            return .error(500, message: error.localizedDescription)
+        } catch {
+            return .error(500, message: "\(error)")
+        }
+    }
+
+    static func createContainer(engine: ContainerEngine, name: String?, body: Data) async -> HTTPResponse {
+        guard let decoded = try? JSONDecoder().decode(DockerContainerCreateBody.self, from: body) else {
+            return .error(400, message: "invalid JSON body")
+        }
+
+        var env: [String: String] = [:]
+        for e in decoded.Env ?? [] {
+            let parts = e.split(separator: "=", maxSplits: 1)
+            if parts.count == 2 { env[String(parts[0])] = String(parts[1]) }
+        }
+
+        var ports: [PortMapping] = []
+        for (containerPort, bindings) in decoded.HostConfig?.PortBindings ?? [:] {
+            for binding in bindings {
+                let proto: PortProtocol = containerPort.hasSuffix("/udp") ? .udp : .tcp
+                let cPort = UInt16(containerPort.split(separator: "/").first ?? "") ?? 0
+                let hPort = UInt16(binding.HostPort) ?? 0
+                ports.append(PortMapping(hostPort: hPort, containerPort: cPort, portProtocol: proto))
+            }
+        }
+
+        var volumes: [VolumeMount] = []
+        for bind in decoded.HostConfig?.Binds ?? [] {
+            let parts = bind.split(separator: ":").map(String.init)
+            if parts.count >= 2 {
+                let ro = parts.count >= 3 && parts[2] == "ro"
+                volumes.append(VolumeMount(source: parts[0], destination: parts[1], readOnly: ro))
+            }
+        }
+
+        var config = ContainerConfig(
+            name: name,
+            image: decoded.Image,
+            command: decoded.Cmd ?? [],
+            environment: env,
+            ports: ports,
+            volumes: volumes,
+            labels: decoded.Labels ?? [:]
+        )
+        if let wd = decoded.WorkingDir { config.workingDir = wd }
+        if let user = decoded.User { config.user = user }
+        if let ep = decoded.Entrypoint { config.entrypoint = ep.first }
+
+        do {
+            let c = try await engine.run(config)
+            struct CreateResponse: Encodable, Sendable {
+                let Id: String
+                let Warnings: [String]
+            }
+            return .json(201, body: CreateResponse(Id: c.id, Warnings: []))
+        } catch let err as MockerError {
+            if case .containerAlreadyExists = err {
+                return .error(409, message: err.localizedDescription)
+            }
+            return .error(500, message: err.localizedDescription)
+        } catch {
+            return .error(500, message: "\(error)")
+        }
+    }
+
+    static func listImages(imageManager: ImageManager) async -> HTTPResponse {
+        let images = (try? await imageManager.list()) ?? []
+        let items = images.map { img -> DockerImageListItem in
+            let tag = img.tag.isEmpty ? "latest" : img.tag
+            let sizeSigned = Int64(clamping: img.size)
+            return DockerImageListItem(
+                Id: img.id,
+                RepoTags: ["\(img.repository):\(tag)"],
+                RepoDigests: [],
+                Created: Int64(img.created.timeIntervalSince1970),
+                Size: sizeSigned,
+                VirtualSize: sizeSigned,
+                Labels: [:]
+            )
+        }
+        return .json(body: items)
+    }
+
+    static func inspectImage(imageManager: ImageManager, name: String) async -> HTTPResponse {
+        guard let img = try? await imageManager.inspect(name) else {
+            return .error(404, message: "No such image: \(name)")
+        }
+        let tag = img.tag.isEmpty ? "latest" : img.tag
+        let arch: String = {
+            #if arch(arm64)
+            return "arm64"
+            #else
+            return "amd64"
+            #endif
+        }()
+        let sizeSigned = Int64(clamping: img.size)
+        let inspect = DockerImageInspect(
+            Id: img.id,
+            RepoTags: ["\(img.repository):\(tag)"],
+            RepoDigests: [],
+            Created: ISO8601DateFormatter().string(from: img.created),
+            Size: sizeSigned,
+            VirtualSize: sizeSigned,
+            Labels: [:],
+            Architecture: arch,
+            Os: "linux",
+            Config: DockerImageConfig(
+                Cmd: [],
+                Entrypoint: nil,
+                Env: [],
+                WorkingDir: "",
+                Labels: [:]
+            )
+        )
+        return .json(body: inspect)
+    }
+
+    static func pullImage(imageManager: ImageManager, reference: String) async -> HTTPResponse {
+        guard !reference.isEmpty else {
+            return .error(400, message: "missing fromImage parameter")
+        }
+        do {
+            _ = try await imageManager.pull(reference)
+            // Docker returns a stream of JSON progress objects; for simplicity return a single event
+            struct PullProgress: Encodable, Sendable {
+                let status: String
+                let progressDetail: [String: String]
+                let id: String
+            }
+            let progress = PullProgress(
+                status: "Pull complete",
+                progressDetail: [:],
+                id: reference
+            )
+            return .json(body: progress)
+        } catch {
+            return .error(500, message: "\(error)")
+        }
+    }
+}

--- a/Sources/MockerKit/SocketService/DockerAPIHandlers.swift
+++ b/Sources/MockerKit/SocketService/DockerAPIHandlers.swift
@@ -212,7 +212,8 @@ enum DockerAPIHandlers {
     static func route(
         request: HTTPRequest,
         engine: ContainerEngine,
-        imageManager: ImageManager
+        imageManager: ImageManager,
+        runStore: PendingRunStore
     ) async -> HTTPResponse {
         let path = request.strippedPath
         let method = request.method
@@ -242,8 +243,11 @@ enum DockerAPIHandlers {
         }
 
         if method == "POST" && path == "/containers/create" {
-            let name = request.queryItems["name"]
-            return await createContainer(engine: engine, name: name, body: request.body)
+            return await pendingCreate(
+                runStore: runStore,
+                name: request.queryItems["name"],
+                body: request.body
+            )
         }
 
         if method == "GET" && path.hasPrefix("/containers/") && path.hasSuffix("/json") {
@@ -251,8 +255,15 @@ enum DockerAPIHandlers {
             return await inspectContainer(engine: engine, id: id)
         }
 
+        if method == "POST" && path.hasPrefix("/containers/") && path.hasSuffix("/attach") {
+            let id = midSegment(path, prefix: "/containers/", suffix: "/attach")
+            return await attachContainer(engine: engine, runStore: runStore, id: id)
+        }
+
         if method == "POST" && path.hasPrefix("/containers/") && path.hasSuffix("/start") {
             let id = midSegment(path, prefix: "/containers/", suffix: "/start")
+            // Pending containers are started by the attach handler
+            if await runStore.getConfig(id: id) != nil { return .noContent() }
             return await startContainer(engine: engine, id: id)
         }
 
@@ -261,8 +272,18 @@ enum DockerAPIHandlers {
             return await stopContainer(engine: engine, id: id)
         }
 
+        if method == "POST" && path.hasPrefix("/containers/") && path.hasSuffix("/wait") {
+            let id = midSegment(path, prefix: "/containers/", suffix: "/wait")
+            return await waitContainer(runStore: runStore, id: id)
+        }
+
         if method == "DELETE" && path.hasPrefix("/containers/") {
             let id = String(path.dropFirst("/containers/".count))
+            // Remove pending containers; delegate real containers to the engine
+            if await runStore.getConfig(id: id) != nil {
+                await runStore.remove(id: id)
+                return .noContent()
+            }
             let force = request.queryItems["force"].map { $0 == "1" || $0 == "true" } ?? false
             return await removeContainer(engine: engine, id: id, force: force)
         }
@@ -285,10 +306,11 @@ enum DockerAPIHandlers {
             return await inspectImage(imageManager: imageManager, name: name)
         }
 
-        // Podman libpod API – minimal subset so `podman version` and `podman ps` work
+        // Podman libpod API – subset so `podman version`, `podman ps`, and `podman run` work
         // when CONTAINER_HOST points at the mocker socket.
         if path.hasPrefix("/libpod/") {
             let subpath = String(path.dropFirst("/libpod".count)) // "/libpod/foo" → "/foo"
+
             if method == "GET" && (subpath == "/_ping" || subpath == "/ping") {
                 return .text(200, body: "OK")
             }
@@ -305,8 +327,47 @@ enum DockerAPIHandlers {
                 let all = request.queryItems["all"].map { $0 == "1" || $0 == "true" } ?? false
                 return await listContainers(engine: engine, all: all)
             }
+            if method == "POST" && subpath == "/containers/create" {
+                return await pendingCreate(
+                    runStore: runStore,
+                    name: request.queryItems["name"],
+                    body: request.body,
+                    libpod: true
+                )
+            }
+            if method == "POST" && subpath.hasPrefix("/containers/") && subpath.hasSuffix("/attach") {
+                let id = midSegment(subpath, prefix: "/containers/", suffix: "/attach")
+                return await attachContainer(engine: engine, runStore: runStore, id: id)
+            }
+            if method == "POST" && subpath.hasPrefix("/containers/") && subpath.hasSuffix("/start") {
+                let id = midSegment(subpath, prefix: "/containers/", suffix: "/start")
+                if await runStore.getConfig(id: id) != nil { return .noContent() }
+                return await startContainer(engine: engine, id: id)
+            }
+            if method == "POST" && subpath.hasPrefix("/containers/") && subpath.hasSuffix("/wait") {
+                let id = midSegment(subpath, prefix: "/containers/", suffix: "/wait")
+                return await waitContainer(runStore: runStore, id: id, libpod: true)
+            }
+            if method == "DELETE" && subpath.hasPrefix("/containers/") {
+                let id = String(subpath.dropFirst("/containers/".count))
+                if await runStore.getConfig(id: id) != nil {
+                    await runStore.remove(id: id)
+                    return .noContent()
+                }
+                let force = request.queryItems["force"].map { $0 == "1" || $0 == "true" } ?? false
+                return await removeContainer(engine: engine, id: id, force: force)
+            }
             if method == "GET" && subpath == "/images/json" {
                 return await listImages(imageManager: imageManager)
+            }
+            if method == "POST" && subpath == "/images/pull" {
+                let ref = request.queryItems["reference"] ?? ""
+                return await pullImage(imageManager: imageManager, reference: ref)
+            }
+            if method == "GET" && subpath.hasPrefix("/images/") && subpath.hasSuffix("/json") {
+                let name = midSegment(subpath, prefix: "/images/", suffix: "/json")
+                    .removingPercentEncoding ?? ""
+                return await inspectImage(imageManager: imageManager, name: name)
             }
             return .error(404, message: "libpod endpoint not implemented: \(path)")
         }
@@ -526,65 +587,6 @@ extension DockerAPIHandlers {
         }
     }
 
-    static func createContainer(engine: ContainerEngine, name: String?, body: Data) async -> HTTPResponse {
-        guard let decoded = try? JSONDecoder().decode(DockerContainerCreateBody.self, from: body) else {
-            return .error(400, message: "invalid JSON body")
-        }
-
-        var env: [String: String] = [:]
-        for e in decoded.Env ?? [] {
-            let parts = e.split(separator: "=", maxSplits: 1)
-            if parts.count == 2 { env[String(parts[0])] = String(parts[1]) }
-        }
-
-        var ports: [PortMapping] = []
-        for (containerPort, bindings) in decoded.HostConfig?.PortBindings ?? [:] {
-            for binding in bindings {
-                let proto: PortProtocol = containerPort.hasSuffix("/udp") ? .udp : .tcp
-                let cPort = UInt16(containerPort.split(separator: "/").first ?? "") ?? 0
-                let hPort = UInt16(binding.HostPort) ?? 0
-                ports.append(PortMapping(hostPort: hPort, containerPort: cPort, portProtocol: proto))
-            }
-        }
-
-        var volumes: [VolumeMount] = []
-        for bind in decoded.HostConfig?.Binds ?? [] {
-            let parts = bind.split(separator: ":").map(String.init)
-            if parts.count >= 2 {
-                let ro = parts.count >= 3 && parts[2] == "ro"
-                volumes.append(VolumeMount(source: parts[0], destination: parts[1], readOnly: ro))
-            }
-        }
-
-        var config = ContainerConfig(
-            name: name,
-            image: decoded.Image,
-            command: decoded.Cmd ?? [],
-            environment: env,
-            ports: ports,
-            volumes: volumes,
-            labels: decoded.Labels ?? [:]
-        )
-        if let wd = decoded.WorkingDir { config.workingDir = wd }
-        if let user = decoded.User { config.user = user }
-        if let ep = decoded.Entrypoint { config.entrypoint = ep.first }
-
-        do {
-            let c = try await engine.run(config)
-            struct CreateResponse: Encodable, Sendable {
-                let Id: String
-                let Warnings: [String]
-            }
-            return .json(201, body: CreateResponse(Id: c.id, Warnings: []))
-        } catch let err as MockerError {
-            if case .containerAlreadyExists = err {
-                return .error(409, message: err.localizedDescription)
-            }
-            return .error(500, message: err.localizedDescription)
-        } catch {
-            return .error(500, message: "\(error)")
-        }
-    }
 
     static func listImages(imageManager: ImageManager) async -> HTTPResponse {
         let images = (try? await imageManager.list()) ?? []
@@ -659,5 +661,127 @@ extension DockerAPIHandlers {
         } catch {
             return .error(500, message: "\(error)")
         }
+    }
+
+    // MARK: - Pending-run create / attach / wait
+
+    /// `POST /containers/create` (Docker) and `POST /libpod/containers/create` (Podman).
+    ///
+    /// Stores the container config in `PendingRunStore` and returns a synthetic container ID.
+    /// The container is not actually started until `POST /containers/{id}/attach` is received.
+    static func pendingCreate(
+        runStore: PendingRunStore,
+        name: String?,
+        body: Data,
+        libpod: Bool = false
+    ) async -> HTTPResponse {
+        let image: String
+        let cmd: [String]
+        let rm: Bool
+
+        if libpod {
+            struct LibpodCreate: Decodable, Sendable {
+                let image: String
+                let command: [String]?
+                let remove: Bool?
+                let name: String?
+            }
+            guard let decoded = try? JSONDecoder().decode(LibpodCreate.self, from: body) else {
+                return .error(400, message: "invalid JSON body")
+            }
+            image = decoded.image
+            cmd = decoded.command ?? []
+            rm = decoded.remove ?? false
+        } else {
+            guard let decoded = try? JSONDecoder().decode(DockerContainerCreateBody.self, from: body) else {
+                return .error(400, message: "invalid JSON body")
+            }
+            image = decoded.Image
+            cmd = decoded.Cmd ?? []
+            rm = false
+        }
+
+        var config = ContainerConfig(name: name, image: image, command: cmd)
+        config.rm = rm
+
+        let id = await runStore.create(config: config)
+        struct CreateResponse: Encodable, Sendable { let Id: String; let Warnings: [String] }
+        return .json(201, body: CreateResponse(Id: id, Warnings: []))
+    }
+
+    /// `POST /containers/{id}/attach` — HTTP 101 hijack, runs the container, streams output.
+    static func attachContainer(
+        engine: ContainerEngine,
+        runStore: PendingRunStore,
+        id: String
+    ) async -> HTTPResponse {
+        guard let config = await runStore.getConfig(id: id) else {
+            return .error(404, message: "No such container: \(id)")
+        }
+        return HTTPResponse.hijack { fd in
+            do {
+                let (stdout, stderr, exitCode) = try await engine.runWithOutputCapture(config)
+                if !stdout.isEmpty { DockerAPIServer.writeDockerFrame(fd: fd, type: 1, data: stdout) }
+                if !stderr.isEmpty { DockerAPIServer.writeDockerFrame(fd: fd, type: 2, data: stderr) }
+                await runStore.recordExit(id: id, code: exitCode)
+            } catch {
+                let msg = Data("\(error)\n".utf8)
+                DockerAPIServer.writeDockerFrame(fd: fd, type: 2, data: msg)
+                await runStore.recordExit(id: id, code: 1)
+            }
+        }
+    }
+
+    /// `POST /containers/{id}/wait` — blocks until the container exits, returns its exit code.
+    static func waitContainer(
+        runStore: PendingRunStore,
+        id: String,
+        libpod: Bool = false
+    ) async -> HTTPResponse {
+        let exitCode = await runStore.waitForExit(id: id)
+        if libpod {
+            struct LibpodWait: Encodable, Sendable {
+                struct WaitError: Encodable, Sendable { let Message: String }
+                let Error: WaitError
+                let StatusCode: Int32
+            }
+            return .json(body: LibpodWait(Error: .init(Message: ""), StatusCode: exitCode))
+        }
+        struct WaitResponse: Encodable, Sendable { let StatusCode: Int32 }
+        return .json(body: WaitResponse(StatusCode: exitCode))
+    }
+}
+
+// MARK: - libpod version response
+
+extension DockerAPIHandlers {
+    static func libpodVersionResponse() -> HTTPResponse {
+        struct LibpodVersionInfo: Encodable, Sendable {
+            let APIVersion: String
+            let Arch: String
+            let BuildTime: String
+            let GitCommit: String
+            let GoVersion: String
+            let MinAPIVersion: String
+            let Os: String
+            let Version: String
+        }
+        let arch: String = {
+            #if arch(arm64)
+            return "arm64"
+            #else
+            return "amd64"
+            #endif
+        }()
+        return .json(body: LibpodVersionInfo(
+            APIVersion: "5.0.0",
+            Arch: arch,
+            BuildTime: "",
+            GitCommit: "",
+            GoVersion: "",
+            MinAPIVersion: "4.0.0",
+            Os: "linux",
+            Version: MockerConfig.mockerVersion
+        ))
     }
 }

--- a/Sources/MockerKit/SocketService/DockerAPIHandlers.swift
+++ b/Sources/MockerKit/SocketService/DockerAPIHandlers.swift
@@ -348,14 +348,27 @@ enum DockerAPIHandlers {
                 let id = midSegment(subpath, prefix: "/containers/", suffix: "/wait")
                 return await waitContainer(runStore: runStore, id: id, libpod: true)
             }
+            if method == "GET" && subpath.hasPrefix("/containers/") && subpath.hasSuffix("/json") {
+                let id = midSegment(subpath, prefix: "/containers/", suffix: "/json")
+                return await libpodInspectContainer(engine: engine, runStore: runStore, id: id)
+            }
             if method == "DELETE" && subpath.hasPrefix("/containers/") {
                 let id = String(subpath.dropFirst("/containers/".count))
+                struct RmReport: Encodable, Sendable { let Id: String }
                 if await runStore.getConfig(id: id) != nil {
                     await runStore.remove(id: id)
-                    return .noContent()
+                    return .json(body: [RmReport(Id: id)])
                 }
                 let force = request.queryItems["force"].map { $0 == "1" || $0 == "true" } ?? false
-                return await removeContainer(engine: engine, id: id, force: force)
+                do {
+                    _ = try await engine.remove(id, force: force)
+                    return .json(body: [RmReport(Id: id)])
+                } catch let error as MockerError {
+                    if case .containerNotFound = error { return .error(404, message: error.localizedDescription) }
+                    return .error(500, message: error.localizedDescription)
+                } catch {
+                    return .error(500, message: "\(error)")
+                }
             }
             if method == "GET" && subpath == "/images/json" {
                 return await listImages(imageManager: imageManager)
@@ -543,6 +556,76 @@ extension DockerAPIHandlers {
             Mounts: []
         )
         return .json(body: inspect)
+    }
+
+    static func libpodInspectContainer(engine: ContainerEngine, runStore: PendingRunStore, id: String) async -> HTTPResponse {
+        struct LibpodState: Encodable, Sendable {
+            let Status: String
+            let Running: Bool
+            let ExitCode: Int32
+            let Dead: Bool
+            let Pid: Int
+            let OOMKilled: Bool
+            let Error: String
+            let StartedAt: String
+            let FinishedAt: String
+        }
+        struct LibpodConfig: Encodable, Sendable { let Image: String }
+        struct LibpodInspect: Encodable, Sendable {
+            let Id: String
+            let Name: String
+            let State: LibpodState
+            let Image: String
+            let ImageName: String
+            let Config: LibpodConfig
+        }
+        let iso = ISO8601DateFormatter()
+        let epoch = "0001-01-01T00:00:00Z"
+        let now = iso.string(from: Date())
+        if let entry = await runStore.getEntry(id: id) {
+            let status = entry.exited ? "exited" : "running"
+            return .json(body: LibpodInspect(
+                Id: id,
+                Name: entry.config.name ?? id,
+                State: LibpodState(
+                    Status: status,
+                    Running: !entry.exited,
+                    ExitCode: entry.exitCode,
+                    Dead: false,
+                    Pid: 0,
+                    OOMKilled: false,
+                    Error: "",
+                    StartedAt: now,
+                    FinishedAt: entry.exited ? now : epoch
+                ),
+                Image: entry.config.image,
+                ImageName: entry.config.image,
+                Config: LibpodConfig(Image: entry.config.image)
+            ))
+        }
+        // Fall back to engine container
+        guard let c = try? await engine.inspect(id) else {
+            return .error(404, message: "No such container: \(id)")
+        }
+        let running = c.state == .running
+        return .json(body: LibpodInspect(
+            Id: c.id,
+            Name: c.name,
+            State: LibpodState(
+                Status: c.state.rawValue,
+                Running: running,
+                ExitCode: 0,
+                Dead: c.state == .dead,
+                Pid: c.pid ?? 0,
+                OOMKilled: false,
+                Error: "",
+                StartedAt: running ? now : epoch,
+                FinishedAt: running ? epoch : now
+            ),
+            Image: c.image,
+            ImageName: c.image,
+            Config: LibpodConfig(Image: c.image)
+        ))
     }
 
     static func startContainer(engine: ContainerEngine, id: String) async -> HTTPResponse {

--- a/Sources/MockerKit/SocketService/DockerAPIHandlers.swift
+++ b/Sources/MockerKit/SocketService/DockerAPIHandlers.swift
@@ -825,12 +825,7 @@ extension DockerAPIHandlers {
             return .error(404, message: "No such container: \(id)")
         }
         if libpod {
-            struct LibpodWait: Encodable, Sendable {
-                struct WaitError: Encodable, Sendable { let Message: String }
-                let Error: WaitError
-                let StatusCode: Int32
-            }
-            return .json(body: LibpodWait(Error: .init(Message: ""), StatusCode: exitCode))
+            return .json(body: exitCode)
         }
         struct WaitResponse: Encodable, Sendable { let StatusCode: Int32 }
         return .json(body: WaitResponse(StatusCode: exitCode))

--- a/Sources/MockerKit/SocketService/DockerAPIHandlers.swift
+++ b/Sources/MockerKit/SocketService/DockerAPIHandlers.swift
@@ -721,8 +721,10 @@ extension DockerAPIHandlers {
         return HTTPResponse.hijack { fd in
             do {
                 let (stdout, stderr, exitCode) = try await engine.runWithOutputCapture(config)
-                if !stdout.isEmpty { DockerAPIServer.writeDockerFrame(fd: fd, type: 1, data: stdout) }
+                // stderr carries VM startup progress (e.g. [0/6] Fetching image), which
+                // happens before the container command runs, so emit it before stdout.
                 if !stderr.isEmpty { DockerAPIServer.writeDockerFrame(fd: fd, type: 2, data: stderr) }
+                if !stdout.isEmpty { DockerAPIServer.writeDockerFrame(fd: fd, type: 1, data: stdout) }
                 await runStore.recordExit(id: id, code: exitCode)
             } catch {
                 let msg = Data("\(error)\n".utf8)

--- a/Sources/MockerKit/SocketService/DockerAPIServer.swift
+++ b/Sources/MockerKit/SocketService/DockerAPIServer.swift
@@ -478,6 +478,7 @@ public actor DockerAPIServer {
     private static func writeHTTPResponse(fd: Int32, response: HTTPResponse) {
         var head = "HTTP/1.1 \(response.status) \(response.statusText)\r\n"
         for (k, v) in response.headers { head += "\(k): \(v)\r\n" }
+        if response.status != 101 { head += "Connection: close\r\n" }
         head += "\r\n"
 
         var data = Data(head.utf8)

--- a/Sources/MockerKit/SocketService/DockerAPIServer.swift
+++ b/Sources/MockerKit/SocketService/DockerAPIServer.swift
@@ -81,6 +81,7 @@ struct HTTPResponse: Sendable {
                 "Content-Type": "application/json",
                 "Content-Length": "\(data.count)",
                 "Api-Version": DockerAPIServer.apiVersion,
+                "Libpod-API-Version": "5.0.0",
                 "Server": "mocker/\(MockerConfig.mockerVersion)",
             ],
             body: data
@@ -96,6 +97,7 @@ struct HTTPResponse: Sendable {
                 "Content-Type": "text/plain; charset=utf-8",
                 "Content-Length": "\(data.count)",
                 "Api-Version": DockerAPIServer.apiVersion,
+                "Libpod-API-Version": "5.0.0",
                 "Server": "mocker/\(MockerConfig.mockerVersion)",
             ],
             body: data

--- a/Sources/MockerKit/SocketService/DockerAPIServer.swift
+++ b/Sources/MockerKit/SocketService/DockerAPIServer.swift
@@ -1,0 +1,417 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+
+// MARK: - HTTP Types
+
+/// A parsed HTTP/1.1 request received from the client.
+struct HTTPRequest: Sendable {
+    let method: String
+    let path: String
+    let queryItems: [String: String]
+    let headers: [String: String]
+    let body: Data
+
+    /// Path with the `/v{major}.{minor}` prefix stripped, e.g.
+    /// `/v1.47/containers/json` → `/containers/json`.
+    var strippedPath: String {
+        guard path.hasPrefix("/v") else { return path }
+        let tail = path.dropFirst(2) // drop "/v"
+        // skip digits and one dot
+        var idx = tail.startIndex
+        while idx < tail.endIndex, tail[idx].isNumber || tail[idx] == "." {
+            tail.formIndex(after: &idx)
+        }
+        guard idx < tail.endIndex, tail[idx] == "/" else { return path }
+        return String(tail[idx...])
+    }
+}
+
+/// An HTTP response to send back to the client.
+struct HTTPResponse: Sendable {
+    let status: Int
+    let statusText: String
+    let headers: [String: String]
+    let body: Data
+
+    static func json(_ status: Int = 200, body: some Encodable & Sendable) -> HTTPResponse {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = (try? encoder.encode(body)) ?? Data("{}".utf8)
+        return HTTPResponse(
+            status: status,
+            statusText: statusPhrase(status),
+            headers: [
+                "Content-Type": "application/json",
+                "Content-Length": "\(data.count)",
+                "Api-Version": DockerAPIServer.apiVersion,
+                "Server": "mocker/\(MockerConfig.mockerVersion)",
+            ],
+            body: data
+        )
+    }
+
+    static func text(_ status: Int = 200, body: String) -> HTTPResponse {
+        let data = Data(body.utf8)
+        return HTTPResponse(
+            status: status,
+            statusText: statusPhrase(status),
+            headers: [
+                "Content-Type": "text/plain; charset=utf-8",
+                "Content-Length": "\(data.count)",
+                "Api-Version": DockerAPIServer.apiVersion,
+                "Server": "mocker/\(MockerConfig.mockerVersion)",
+            ],
+            body: data
+        )
+    }
+
+    static func error(_ status: Int, message: String) -> HTTPResponse {
+        struct ErrorBody: Encodable, Sendable { let message: String }
+        return json(status, body: ErrorBody(message: message))
+    }
+
+    static func noContent() -> HTTPResponse {
+        HTTPResponse(
+            status: 204,
+            statusText: "No Content",
+            headers: [
+                "Api-Version": DockerAPIServer.apiVersion,
+                "Server": "mocker/\(MockerConfig.mockerVersion)",
+            ],
+            body: Data()
+        )
+    }
+
+    private static func statusPhrase(_ code: Int) -> String {
+        switch code {
+        case 200: "OK"
+        case 201: "Created"
+        case 204: "No Content"
+        case 304: "Not Modified"
+        case 400: "Bad Request"
+        case 404: "Not Found"
+        case 409: "Conflict"
+        case 500: "Internal Server Error"
+        default: "Unknown"
+        }
+    }
+}
+
+// MARK: - Docker API Server
+
+/// Serves the Docker Engine REST API over a Unix-domain socket.
+///
+/// The server can be started in two modes:
+/// - **launchd socket activation**: call ``serve(serverFd:)`` with a socket fd
+///   already bound and listening by launchd.
+/// - **standalone**: call ``serve(socketPath:)`` to create and bind the socket.
+///
+/// In both modes the server exits automatically after `timeout` seconds of
+/// inactivity (no active connections).  Pass `nil` to run indefinitely.
+public actor DockerAPIServer {
+    public nonisolated let containerEngine: ContainerEngine
+    public nonisolated let imageManager: ImageManager
+
+    private var lastActivity: Date = Date()
+    private var activeConnections: Int = 0
+    private let timeout: TimeInterval?
+
+    /// The Docker Engine API version advertised in responses.
+    public static let apiVersion = "1.47"
+
+    public init(config: MockerConfig, timeout: TimeInterval? = nil) throws {
+        self.containerEngine = try ContainerEngine(config: config)
+        self.imageManager = try ImageManager(config: config)
+        self.timeout = timeout
+    }
+
+    // MARK: - Entry Points
+
+    /// Serve on a socket fd already bound and listening (e.g. from launchd activation).
+    public func serve(serverFd: Int32) async throws {
+        startTimeoutMonitor()
+        try await runAcceptLoop(serverFd: serverFd)
+    }
+
+    /// Create a Unix-domain socket at `socketPath` and serve.
+    public func serve(socketPath: String) async throws {
+        try? FileManager.default.removeItem(atPath: socketPath)
+        let serverFd = try Self.bindAndListen(path: socketPath)
+        defer { close(serverFd) }
+        startTimeoutMonitor()
+        try await runAcceptLoop(serverFd: serverFd)
+    }
+
+    // MARK: - Timeout
+
+    private func startTimeoutMonitor() {
+        guard let t = timeout else { return }
+        let capturedTimeout = t
+        Task {
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                if activeConnections == 0,
+                   Date().timeIntervalSince(lastActivity) > capturedTimeout {
+                    exit(0)
+                }
+            }
+        }
+    }
+
+    // MARK: - Activity Tracking
+
+    private func incrementConnections() {
+        activeConnections += 1
+        lastActivity = Date()
+    }
+
+    private func decrementConnections() {
+        activeConnections -= 1
+        lastActivity = Date()
+    }
+
+    // MARK: - Accept Loop
+
+    private func runAcceptLoop(serverFd: Int32) async throws {
+        let engine = containerEngine
+        let imgMgr = imageManager
+        while true {
+            let clientFd = try await Self.acceptAsync(serverFd)
+            incrementConnections()
+            let server = self
+            Task.detached {
+                await Self.handleConnection(
+                    clientFd: clientFd,
+                    engine: engine,
+                    imageManager: imgMgr
+                )
+                close(clientFd)
+                await server.decrementConnections()
+            }
+        }
+    }
+
+    // MARK: - Connection Handler
+
+    private static func handleConnection(
+        clientFd: Int32,
+        engine: ContainerEngine,
+        imageManager: ImageManager
+    ) async {
+        guard let request = await readHTTPRequest(fd: clientFd) else { return }
+        let response = await DockerAPIHandlers.route(
+            request: request,
+            engine: engine,
+            imageManager: imageManager
+        )
+        writeHTTPResponse(fd: clientFd, response: response)
+    }
+
+    // MARK: - Socket Helpers
+
+    /// Create a listening Unix-domain socket at `path`.
+    public static func bindAndListen(path: String) throws -> Int32 {
+        #if canImport(Darwin)
+        let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+        #else
+        let fd = socket(AF_UNIX, Int32(SOCK_STREAM.rawValue), 0)
+        #endif
+        guard fd >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EPERM)
+        }
+
+        var reuseVal: Int32 = 1
+        setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &reuseVal, socklen_t(MemoryLayout<Int32>.size))
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        guard path.utf8.count < MemoryLayout.size(ofValue: addr.sun_path) else {
+            close(fd)
+            throw MockerError.operationFailed("Socket path too long: \(path)")
+        }
+        path.withCString { cStr in
+            withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+                ptr.withMemoryRebound(to: CChar.self, capacity: 104) { dest in
+                    _ = strncpy(dest, cStr, 103)
+                }
+            }
+        }
+
+        let unlink_path = path  // captured for unlink before bind
+        unlink_path.withCString { _ = unlink($0) }
+
+        let bindResult = withUnsafePointer(to: addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sptr in
+                bind(fd, sptr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            close(fd)
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EPERM)
+        }
+
+        guard listen(fd, 128) == 0 else {
+            close(fd)
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EPERM)
+        }
+        return fd
+    }
+
+    /// Bridge the blocking `accept(2)` call to Swift concurrency.
+    private static func acceptAsync(_ serverFd: Int32) async throws -> Int32 {
+        try await withCheckedThrowingContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                let clientFd = accept(serverFd, nil, nil)
+                if clientFd < 0 {
+                    continuation.resume(
+                        throwing: POSIXError(POSIXErrorCode(rawValue: errno) ?? .EPERM)
+                    )
+                } else {
+                    continuation.resume(returning: clientFd)
+                }
+            }
+        }
+    }
+
+    // MARK: - HTTP Parsing
+
+    private static func readHTTPRequest(fd: Int32) async -> HTTPRequest? {
+        var raw = Data()
+        var headerEnd: Int? = nil
+        let marker = Data([0x0D, 0x0A, 0x0D, 0x0A]) // \r\n\r\n
+
+        while raw.count < 131_072 { // 128 KB guard
+            let chunk = await readChunk(fd: fd, maxBytes: 4096)
+            guard !chunk.isEmpty else { break }
+            raw.append(chunk)
+            if let r = raw.range(of: marker) {
+                headerEnd = r.upperBound
+                break
+            }
+        }
+
+        guard let end = headerEnd else { return nil }
+
+        let headerText = String(data: raw.prefix(end), encoding: .utf8) ?? ""
+        let lines = headerText.components(separatedBy: "\r\n").filter { !$0.isEmpty }
+        guard !lines.isEmpty else { return nil }
+
+        // Request line: METHOD PATH HTTP/1.x
+        let reqParts = lines[0].split(separator: " ", maxSplits: 2).map(String.init)
+        guard reqParts.count >= 2 else { return nil }
+
+        let method = reqParts[0]
+        let rawPath = reqParts[1]
+
+        // Split path / query string
+        var path = rawPath
+        var queryItems: [String: String] = [:]
+        if let q = rawPath.firstIndex(of: "?") {
+            path = String(rawPath[..<q])
+            let qs = String(rawPath[rawPath.index(after: q)...])
+            for pair in qs.split(separator: "&") {
+                let kv = pair.split(separator: "=", maxSplits: 1)
+                let key = String(kv[0])
+                let value = kv.count > 1
+                    ? (String(kv[1]).removingPercentEncoding ?? String(kv[1]))
+                    : ""
+                queryItems[key] = value
+            }
+        }
+
+        // Headers (lowercase keys)
+        var headers: [String: String] = [:]
+        for line in lines.dropFirst() {
+            guard let colon = line.firstIndex(of: ":") else { continue }
+            let key = String(line[..<colon]).trimmingCharacters(in: .whitespaces).lowercased()
+            let val = String(line[line.index(after: colon)...]).trimmingCharacters(in: .whitespaces)
+            headers[key] = val
+        }
+
+        // Body
+        var body = Data()
+        if let cl = headers["content-length"].flatMap(Int.init), cl > 0 {
+            let already = raw.count - end
+            if already > 0 { body.append(raw.suffix(already)) }
+            let remaining = cl - body.count
+            if remaining > 0 {
+                let more = await readExact(fd: fd, count: remaining)
+                body.append(more)
+            }
+        }
+
+        return HTTPRequest(
+            method: method,
+            path: path,
+            queryItems: queryItems,
+            headers: headers,
+            body: body
+        )
+    }
+
+    private static func readChunk(fd: Int32, maxBytes: Int) async -> Data {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global(qos: .userInitiated).async {
+                var buf = [UInt8](repeating: 0, count: maxBytes)
+                let n = recv(fd, &buf, maxBytes, 0)
+                continuation.resume(returning: n > 0 ? Data(buf.prefix(n)) : Data())
+            }
+        }
+    }
+
+    private static func readExact(fd: Int32, count: Int) async -> Data {
+        var data = Data()
+        while data.count < count {
+            let chunk = await readChunk(fd: fd, maxBytes: count - data.count)
+            guard !chunk.isEmpty else { break }
+            data.append(chunk)
+        }
+        return data
+    }
+
+    // MARK: - HTTP Writing
+
+    private static func writeHTTPResponse(fd: Int32, response: HTTPResponse) {
+        var head = "HTTP/1.1 \(response.status) \(response.statusText)\r\n"
+        for (k, v) in response.headers { head += "\(k): \(v)\r\n" }
+        head += "\r\n"
+
+        var data = Data(head.utf8)
+        data.append(response.body)
+
+        data.withUnsafeBytes { raw in
+            guard let ptr = raw.baseAddress else { return }
+            var sent = 0
+            while sent < data.count {
+                let n = send(fd, ptr.advanced(by: sent), data.count - sent, 0)
+                guard n > 0 else { break }
+                sent += n
+            }
+        }
+    }
+}
+
+// MARK: - launchd Socket Activation
+
+/// Attempt to acquire a socket fd previously bound by launchd.
+///
+/// Returns the first file descriptor for the socket named `name`, or `nil`
+/// if this process was not started via launchd socket activation.
+/// On non-Darwin platforms (e.g. Linux CI) this always returns `nil`.
+public func launchdActivateSocket(name: String) -> Int32? {
+    #if canImport(Darwin)
+    var fds: UnsafeMutablePointer<Int32>? = nil
+    var count: size_t = 0
+    let result = launch_activate_socket(name, &fds, &count)
+    guard result == 0, let fds, count > 0 else { return nil }
+    let fd = fds[0]
+    free(fds)
+    return fd
+    #else
+    return nil
+    #endif
+}

--- a/Sources/MockerKit/SocketService/DockerAPIServer.swift
+++ b/Sources/MockerKit/SocketService/DockerAPIServer.swift
@@ -159,6 +159,7 @@ actor PendingRunStore {
     }
 
     func getConfig(id: String) -> ContainerConfig? { entries[id]?.config }
+    func getEntry(id: String) -> Entry? { entries[id] }
 
     func recordExit(id: String, code: Int32) {
         guard var e = entries[id] else { return }

--- a/Sources/MockerKit/SocketService/DockerAPIServer.swift
+++ b/Sources/MockerKit/SocketService/DockerAPIServer.swift
@@ -36,6 +36,39 @@ struct HTTPResponse: Sendable {
     let statusText: String
     let headers: [String: String]
     let body: Data
+    /// When non-nil the server writes the response header, then calls this with the raw
+    /// client fd (HTTP 101 / Docker container-attach hijack).
+    let streamHandler: (@Sendable (Int32) async -> Void)?
+
+    init(
+        status: Int,
+        statusText: String,
+        headers: [String: String] = [:],
+        body: Data = Data(),
+        streamHandler: (@Sendable (Int32) async -> Void)? = nil
+    ) {
+        self.status = status
+        self.statusText = statusText
+        self.headers = headers
+        self.body = body
+        self.streamHandler = streamHandler
+    }
+
+    /// HTTP 101 response that hands off the raw fd to `handler`.
+    /// Used for Docker container-attach: server writes the upgrade header then
+    /// streams container output in Docker multiplexed-stream format.
+    static func hijack(_ handler: @escaping @Sendable (Int32) async -> Void) -> HTTPResponse {
+        HTTPResponse(
+            status: 101,
+            statusText: "UPGRADED",
+            headers: [
+                "Content-Type": "application/vnd.docker.raw-stream",
+                "Connection": "Upgrade",
+                "Upgrade": "tcp",
+            ],
+            streamHandler: handler
+        )
+    }
 
     static func json(_ status: Int = 200, body: some Encodable & Sendable) -> HTTPResponse {
         let encoder = JSONEncoder()
@@ -101,6 +134,50 @@ struct HTTPResponse: Sendable {
     }
 }
 
+// MARK: - Pending Run Store
+
+/// Coordinates the Docker/Podman create → attach → start → wait lifecycle.
+///
+/// `POST /containers/create` stores a `ContainerConfig` here.
+/// `POST /containers/{id}/attach` runs the container and streams output.
+/// `POST /containers/{id}/start`  is a no-op (attach already started it).
+/// `POST /containers/{id}/wait`   blocks until attach records the exit code.
+actor PendingRunStore {
+    struct Entry {
+        let config: ContainerConfig
+        var exited = false
+        var exitCode: Int32 = 0
+        var waiters: [CheckedContinuation<Int32, Never>] = []
+    }
+
+    private var entries: [String: Entry] = [:]
+
+    func create(config: ContainerConfig) -> String {
+        let id = UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
+        entries[id] = Entry(config: config)
+        return id
+    }
+
+    func getConfig(id: String) -> ContainerConfig? { entries[id]?.config }
+
+    func recordExit(id: String, code: Int32) {
+        guard var e = entries[id] else { return }
+        e.exited = true
+        e.exitCode = code
+        let waiters = e.waiters
+        e.waiters = []
+        entries[id] = e
+        waiters.forEach { $0.resume(returning: code) }
+    }
+
+    func waitForExit(id: String) async -> Int32 {
+        if let e = entries[id], e.exited { return e.exitCode }
+        return await withCheckedContinuation { entries[id]?.waiters.append($0) }
+    }
+
+    func remove(id: String) { entries.removeValue(forKey: id) }
+}
+
 // MARK: - Docker API Server
 
 /// Serves the Docker Engine REST API over a Unix-domain socket.
@@ -115,6 +192,7 @@ struct HTTPResponse: Sendable {
 public actor DockerAPIServer {
     public nonisolated let containerEngine: ContainerEngine
     public nonisolated let imageManager: ImageManager
+    let runStore = PendingRunStore()
 
     private var lastActivity: Date = Date()
     private var activeConnections: Int = 0
@@ -179,6 +257,7 @@ public actor DockerAPIServer {
     private func runAcceptLoop(serverFd: Int32) async throws {
         let engine = containerEngine
         let imgMgr = imageManager
+        let store = runStore
         while true {
             let clientFd = try await Self.acceptAsync(serverFd)
             incrementConnections()
@@ -187,7 +266,8 @@ public actor DockerAPIServer {
                 await Self.handleConnection(
                     clientFd: clientFd,
                     engine: engine,
-                    imageManager: imgMgr
+                    imageManager: imgMgr,
+                    runStore: store
                 )
                 close(clientFd)
                 await server.decrementConnections()
@@ -200,15 +280,20 @@ public actor DockerAPIServer {
     private static func handleConnection(
         clientFd: Int32,
         engine: ContainerEngine,
-        imageManager: ImageManager
+        imageManager: ImageManager,
+        runStore: PendingRunStore
     ) async {
         guard let request = await readHTTPRequest(fd: clientFd) else { return }
         let response = await DockerAPIHandlers.route(
             request: request,
             engine: engine,
-            imageManager: imageManager
+            imageManager: imageManager,
+            runStore: runStore
         )
         writeHTTPResponse(fd: clientFd, response: response)
+        if let handler = response.streamHandler {
+            await handler(clientFd)
+        }
     }
 
     // MARK: - Socket Helpers
@@ -394,9 +479,39 @@ public actor DockerAPIServer {
             }
         }
     }
+    // MARK: - Docker Multiplexed-Stream Frame
+
+    /// Write one Docker multiplexed-stream frame directly to a raw fd.
+    ///
+    /// Frame layout: `[type(1)] [0,0,0] [payloadSize(4 BE)] [payload]`
+    ///
+    /// - Parameters:
+    ///   - fd:   Raw client file descriptor from the accept loop.
+    ///   - type: `1` = stdout, `2` = stderr.
+    ///   - data: Payload bytes to include in this frame.
+    static func writeDockerFrame(fd: Int32, type: UInt8, data: Data) {
+        guard !data.isEmpty else { return }
+        var frame = Data(repeating: 0, count: 8)
+        frame[0] = type
+        let size = UInt32(data.count)
+        frame[4] = UInt8((size >> 24) & 0xFF)
+        frame[5] = UInt8((size >> 16) & 0xFF)
+        frame[6] = UInt8((size >> 8) & 0xFF)
+        frame[7] = UInt8(size & 0xFF)
+        var out = frame
+        out.append(data)
+        out.withUnsafeBytes { raw in
+            guard let ptr = raw.baseAddress else { return }
+            var sent = 0
+            while sent < out.count {
+                let n = send(fd, ptr.advanced(by: sent), out.count - sent, 0)
+                guard n > 0 else { break }
+                sent += n
+            }
+        }
+    }
 }
 
-// MARK: - launchd Socket Activation
 
 /// Attempt to acquire a socket fd previously bound by launchd.
 ///

--- a/Sources/MockerKit/SocketService/DockerAPIServer.swift
+++ b/Sources/MockerKit/SocketService/DockerAPIServer.swift
@@ -407,7 +407,15 @@ public func launchdActivateSocket(name: String) -> Int32? {
     #if canImport(Darwin)
     var fds: UnsafeMutablePointer<Int32>? = nil
     var count: size_t = 0
-    let result = launch_activate_socket(name, &fds, &count)
+    // launch_activate_socket expects UnsafeMutablePointer<UnsafeMutablePointer<Int32>> (non-optional
+    // inner pointer), but &fds from an Optional gives the optional-inner variant. Rebind the
+    // storage — Optional<UnsafeMutablePointer<Int32>> and UnsafeMutablePointer<Int32> have the
+    // same memory layout (8 bytes; nil == null pointer), so this is safe.
+    let result: Int32 = withUnsafeMutablePointer(to: &fds) { optPtr in
+        optPtr.withMemoryRebound(to: UnsafeMutablePointer<Int32>.self, capacity: 1) { ptr in
+            launch_activate_socket(name, ptr, &count)
+        }
+    }
     guard result == 0, let fds, count > 0 else { return nil }
     let fd = fds[0]
     free(fds)

--- a/Sources/MockerKit/SocketService/DockerAPIServer.swift
+++ b/Sources/MockerKit/SocketService/DockerAPIServer.swift
@@ -235,6 +235,7 @@ public actor DockerAPIServer {
         }
         path.withCString { cStr in
             withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+                // 104 = sizeof(sockaddr_un.sun_path) on macOS/Linux; leave room for NUL terminator (103 chars max).
                 ptr.withMemoryRebound(to: CChar.self, capacity: 104) { dest in
                     _ = strncpy(dest, cStr, 103)
                 }
@@ -284,7 +285,7 @@ public actor DockerAPIServer {
         var headerEnd: Int? = nil
         let marker = Data([0x0D, 0x0A, 0x0D, 0x0A]) // \r\n\r\n
 
-        while raw.count < 131_072 { // 128 KB guard
+        while raw.count < 131_072 { // 128 KB guard: limits memory use from malformed/malicious headers
             let chunk = await readChunk(fd: fd, maxBytes: 4096)
             guard !chunk.isEmpty else { break }
             raw.append(chunk)

--- a/Sources/MockerKit/SocketService/DockerAPIServer.swift
+++ b/Sources/MockerKit/SocketService/DockerAPIServer.swift
@@ -170,12 +170,26 @@ actor PendingRunStore {
         waiters.forEach { $0.resume(returning: code) }
     }
 
-    func waitForExit(id: String) async -> Int32 {
-        if let e = entries[id], e.exited { return e.exitCode }
-        return await withCheckedContinuation { entries[id]?.waiters.append($0) }
+    func waitForExit(id: String) async -> Int32? {
+        if let e = entries[id] {
+            if e.exited { return e.exitCode }
+            return await withCheckedContinuation { continuation in
+                guard var entry = entries[id] else {
+                    continuation.resume(returning: 0)
+                    return
+                }
+                entry.waiters.append(continuation)
+                entries[id] = entry
+            }
+        }
+        return nil
     }
 
-    func remove(id: String) { entries.removeValue(forKey: id) }
+    func remove(id: String) {
+        guard let entry = entries.removeValue(forKey: id) else { return }
+        let code = entry.exitCode
+        entry.waiters.forEach { $0.resume(returning: code) }
+    }
 }
 
 // MARK: - Docker API Server
@@ -314,15 +328,15 @@ public actor DockerAPIServer {
 
         var addr = sockaddr_un()
         addr.sun_family = sa_family_t(AF_UNIX)
-        guard path.utf8.count < MemoryLayout.size(ofValue: addr.sun_path) else {
+        let sunPathCapacity = MemoryLayout.size(ofValue: addr.sun_path)
+        guard path.utf8.count < sunPathCapacity else {
             close(fd)
             throw MockerError.operationFailed("Socket path too long: \(path)")
         }
         path.withCString { cStr in
             withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
-                // 104 = sizeof(sockaddr_un.sun_path) on macOS/Linux; leave room for NUL terminator (103 chars max).
-                ptr.withMemoryRebound(to: CChar.self, capacity: 104) { dest in
-                    _ = strncpy(dest, cStr, 103)
+                ptr.withMemoryRebound(to: CChar.self, capacity: sunPathCapacity) { dest in
+                    _ = strncpy(dest, cStr, sunPathCapacity - 1)
                 }
             }
         }

--- a/Tests/MockerKitTests/DockerAPIServerTests.swift
+++ b/Tests/MockerKitTests/DockerAPIServerTests.swift
@@ -1,0 +1,109 @@
+import Testing
+import Foundation
+@testable import MockerKit
+
+@Suite("DockerAPIServer Tests")
+struct DockerAPIServerTests {
+
+    @Test("HTTPRequest strips API version prefix")
+    func testStrippedPath() {
+        let req = HTTPRequest(
+            method: "GET",
+            path: "/v1.47/containers/json",
+            queryItems: [:],
+            headers: [:],
+            body: Data()
+        )
+        #expect(req.strippedPath == "/containers/json")
+    }
+
+    @Test("HTTPRequest strips two-digit minor version")
+    func testStrippedPathTwoDigit() {
+        let req = HTTPRequest(
+            method: "GET",
+            path: "/v1.100/images/json",
+            queryItems: [:],
+            headers: [:],
+            body: Data()
+        )
+        #expect(req.strippedPath == "/images/json")
+    }
+
+    @Test("HTTPRequest passes through non-versioned path")
+    func testStrippedPathNoVersion() {
+        let req = HTTPRequest(
+            method: "GET",
+            path: "/_ping",
+            queryItems: [:],
+            headers: [:],
+            body: Data()
+        )
+        #expect(req.strippedPath == "/_ping")
+    }
+
+    @Test("HTTPResponse.json produces correct Content-Type header")
+    func testJSONResponseHeaders() {
+        struct Payload: Encodable, Sendable { let ok: Bool }
+        let resp = HTTPResponse.json(body: Payload(ok: true))
+        #expect(resp.status == 200)
+        #expect(resp.headers["Content-Type"] == "application/json")
+        #expect(resp.headers["Api-Version"] == DockerAPIServer.apiVersion)
+    }
+
+    @Test("HTTPResponse.text produces correct headers")
+    func testTextResponseHeaders() {
+        let resp = HTTPResponse.text(body: "OK")
+        #expect(resp.status == 200)
+        #expect(resp.headers["Content-Type"]?.hasPrefix("text/plain") == true)
+    }
+
+    @Test("HTTPResponse.noContent produces 204 with empty body")
+    func testNoContentResponse() {
+        let resp = HTTPResponse.noContent()
+        #expect(resp.status == 204)
+        #expect(resp.body.isEmpty)
+    }
+
+    @Test("HTTPResponse.error produces expected JSON")
+    func testErrorResponse() throws {
+        let resp = HTTPResponse.error(404, message: "not found")
+        #expect(resp.status == 404)
+        let json = try JSONDecoder().decode([String: String].self, from: resp.body)
+        #expect(json["message"] == "not found")
+    }
+
+    @Test("versionResponse returns correct API version")
+    func testVersionResponse() throws {
+        let resp = DockerAPIHandlers.versionResponse()
+        #expect(resp.status == 200)
+        let json = try JSONDecoder().decode([String: AnyCodable].self, from: resp.body)
+        #expect(json["ApiVersion"]?.stringValue == DockerAPIServer.apiVersion)
+    }
+
+    @Test("MockerConfig includes socketPath")
+    func testSocketPath() {
+        let config = MockerConfig()
+        #expect(config.socketPath.hasSuffix("mocker.sock"))
+    }
+
+    @Test("MockerConfig includes launchAgentPlistPath")
+    func testLaunchAgentPlistPath() {
+        let config = MockerConfig()
+        #expect(config.launchAgentPlistPath.hasSuffix(".plist"))
+        #expect(config.launchAgentPlistPath.contains("LaunchAgents"))
+    }
+
+    @Test("MockerConfig has correct launchAgentLabel")
+    func testLaunchAgentLabel() {
+        #expect(MockerConfig.launchAgentLabel == "io.mocker.socket")
+    }
+}
+
+// Minimal helper to decode any JSON value for test assertions.
+private struct AnyCodable: Decodable {
+    let stringValue: String?
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        stringValue = try? container.decode(String.self)
+    }
+}


### PR DESCRIPTION
Closes us/mocker#7

## Architecture

```mermaid
graph TD
    subgraph clients["Client Tools"]
        D["Docker CLI\ndocker run / ps / images"]
        P["Podman CLI\npodman run / ps / images"]
        SDK["Docker/Podman SDKs\nGo · Python · etc."]
    end

    subgraph launchd["macOS launchd — socket activation"]
        PLIST["io.mocker.socket.plist\n↳ mocker socket install"]
        SOCK["~/.mocker/mocker.sock\n(fd owned by launchd)"]
        PLIST -->|"bootstrap / enable"| SOCK
    end

    D -->|"DOCKER_HOST=unix://…"| SOCK
    P -->|"CONTAINER_HOST=unix://…"| SOCK
    SDK -->|"DOCKER_HOST=unix://…"| SOCK

    SOCK -->|"on connect: spawn"| SVC

    subgraph service["mocker system service  ← this PR"]
        SVC["DockerAPIServer\nHTTP/1.1 · Connection: close\nLibpod-API-Version header"]
        HDL["DockerAPIHandlers\nDocker Engine API v1.47\nPodman libpod API v5.0.0"]
        STORE["PendingRunStore\nin-flight container state\n+ exit-code signalling"]
        SVC --> HDL
        HDL <-->|"create / wait / inspect / remove"| STORE
    end

    SVC -->|"inactivity timeout → exit\nlaunchd resumes socket"| SOCK

    subgraph existing["Existing mocker code"]
        CE["ContainerEngine\nrunStreaming · run · stop\ninspect · remove · exec"]
        IM["ImageManager\npull · build · list · inspect"]
    end

    HDL -->|"container lifecycle"| CE
    HDL -->|"image ops"| IM

    subgraph apple["Apple Containerization"]
        CLI["/usr/local/bin/container\nApple container CLI"]
        IS["Containerization.ImageStore\n(direct framework)"]
        VZ["Virtualization.framework\none Linux VM per container"]
    end

    CE -->|"exec subprocess"| CLI
    IM -->|"direct API"| IS
    CLI --> VZ
```

## Checklist

### Original review fixes
- [x] Fix `PendingRunStore.waitForExit` hang on unknown IDs + `remove` not notifying waiters (`DockerAPIServer.swift`)
- [x] Fix `waitContainer` missing 404 for unknown container IDs (`DockerAPIHandlers.swift`)
- [x] Fix `runWithOutputCapture` pipe buffer deadlock by draining pipes concurrently (`ContainerEngine.swift`)
- [x] Fix `bindAndListen` magic numbers 104/103 → `MemoryLayout` (`DockerAPIServer.swift`)
- [x] Fix launchd template `RunAtLoad=true`+`KeepAlive=true` negating timeout (`README.md`, `README.zh-CN.md`)
- [x] Fix CI push trigger to only include `main` branch (`ci.yml`)

### Runtime fixes (verified end-to-end)
- [x] Add `Connection: close` header — fixes "server closed idle connection" on `docker run --rm` (`DockerAPIServer.swift`)
- [x] Replace `runWithOutputCapture` with `runStreaming` in attach handler — eliminates hang during large image downloads; progress and output now appear in real time (`ContainerEngine.swift`, `DockerAPIHandlers.swift`)
- [x] Add `GET /libpod/containers/{id}/json` — `podman run --rm` inspect after exit (`DockerAPIHandlers.swift`)
- [x] Fix `DELETE /libpod/containers/{id}` — return `[{"Id":"…"}]` JSON array; was returning empty 204, causing podman `ERRO: unexpected end of JSON input` on `--rm` cleanup (`DockerAPIHandlers.swift`)
- [x] Fix `POST /libpod/containers/{id}/wait` — return plain `int32` exit code; was returning `{"Error":…,"StatusCode":0}` object, causing podman unmarshal error (`DockerAPIHandlers.swift`)
- [x] Add `Libpod-API-Version: 5.0.0` header — suppresses `WARN: Service did not provide Libpod-API-Version Header` (`DockerAPIServer.swift`)

## Acceptance criteria (issue #7)
- [x] `mocker system service` starts, accepts launchd-inherited socket fd, serves Docker Engine REST API
- [x] `mocker socket install` installs launchd plist and activates socket
- [x] `DOCKER_HOST=unix://~/.mocker/mocker.sock docker ps` works
- [x] `CONTAINER_HOST=unix://~/.mocker/mocker.sock podman run --rm alpine cat /etc/os-release` works
- [ ] `podman --remote --url unix://~/.mocker/mocker.sock ps` — not yet explicitly tested
- [ ] Docker SDK clients (Go, Python) — not yet tested
- [x] Zero additional processes when idle (`launchd` holds the socket)
- [x] `mocker system service` exits after inactivity timeout

> [!Note]
> Responses generated with Claude