### PR TITLE
fix(compose): forward port mappings to container run (-p)

### DIFF
--- a/Sources/MockerKit/Container/ContainerEngine.swift
+++ b/Sources/MockerKit/Container/ContainerEngine.swift
@@ -91,6 +91,10 @@ public actor ContainerEngine {
             }
         }
 
+        for port in containerConfig.ports {
+            args += ["-p", port.description]
+        }
+
         if let workingDir = containerConfig.workingDir, !workingDir.isEmpty {
             args += ["-w", workingDir]
         }

--- a/Tests/MockerKitTests/ContainerEngineTests.swift
+++ b/Tests/MockerKitTests/ContainerEngineTests.swift
@@ -144,6 +144,22 @@ struct ContainerEngineTests {
         #expect(args.contains("/path/to/kernel"))
     }
 
+    @Test("Run arguments include port mappings as -p flags")
+    func testRunArgumentsIncludePortMappings() throws {
+        let port1 = try PortMapping.parse("8080:80")
+        let port2 = try PortMapping.parse("443:443/tcp")
+        let config = ContainerConfig(
+            image: "nginx:latest",
+            ports: [port1, port2]
+        )
+
+        let args = ContainerEngine.buildRunArguments(name: "port-test", config: config)
+
+        #expect(args.contains("-p"))
+        #expect(args.contains("8080:80/tcp"))
+        #expect(args.contains("443:443/tcp"))
+    }
+
     @Test("Container CLI resolver prefers Homebrew installation")
     func testContainerCLIResolverPrefersHomebrew() throws {
         let root = URL(fileURLWithPath: NSTemporaryDirectory())


### PR DESCRIPTION
Fixes #19.

## Problem

`mocker compose up` showed port mappings in `mocker compose ps` output but no ports were actually reachable on the host — every published port returned `ECONNREFUSED`. Meanwhile, the native `container run -p <port>` worked correctly.

## Root cause

`ContainerEngine.buildRunArguments()` never included `-p` flags when building the `container run` argument list. Instead, it relied on `PortProxy` — a background subprocess (`mocker __proxy`) that creates a `NWListener` to relay TCP traffic to the container IP. This proxy fails because:

1. The mocker CLI binary lacks the `com.apple.security.network.server` entitlement needed to bind host ports
2. `NWListener` requires App Sandbox or the network server entitlement, neither of which the CLI has

The native `container` CLI already handles port forwarding correctly when invoked with `-p`, so the simplest fix is to pass the port mappings directly.

## Changes

**`Sources/MockerKit/Container/ContainerEngine.swift`** — Added `-p` flags to `buildRunArguments()` (4 lines):

```swift
for port in containerConfig.ports {
    args += ["-p", port.description]
}
```

**`Tests/MockerKitTests/ContainerEngineTests.swift`** — New unit test `testRunArgumentsIncludePortMappings` (16 lines) verifies:
- `-p` flag is present in the argument list
- Port values appear in the expected `host:container/protocol` format

## Tests

- `swift build` — compiles without errors
- `swift test` — **82 tests in 9 suites pass** (including new test)
- Manual end-to-end verification: clean `mocker compose down && mocker compose up -d` with a 5-service compose file — all 5 ports respond `OPEN` (previously all `ECONNREFUSED`)
- Minimal reproduction: single nginx service — port `18080:80` confirmed reachable