### PR TITLE
fix!: make image inspect Docker-compatible and honor inspect --type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Mocker are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### ⚠ BREAKING CHANGES
+
+* **image inspect:** `mocker image inspect` and `mocker inspect --type=image` now return Docker-compatible `ImageInspect` JSON arrays with PascalCase keys instead of the previous lowercase `ImageInfo` object shape.
+* **MockerKit:** `ImageManager.inspect(_:platform:)` returns `ImageInspect` instead of `ImageInfo`.
+
 ## [0.3.2](https://github.com/us/mocker/compare/v0.3.1...v0.3.2) (2026-06-11)
 
 

--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -329,8 +329,13 @@ mocker inspect [OPTIONS] NAME|ID [NAME|ID...]
 | Flag | Short | Description |
 |------|-------|-------------|
 | `--format` | `-f` | Format output using a custom template |
-| `--type` | | Only inspect objects of the given type |
+| `--type` | | Only inspect objects of the given type (`image` or `container`) |
+| `--platform` | | Inspect a specific image platform (for example `linux/amd64`) |
 | `--size` | `-s` | Display total file sizes if type is container |
+
+Image targets return Docker-compatible `ImageInspect` JSON arrays with PascalCase
+fields. `mocker inspect --type image IMAGE` and `mocker image inspect IMAGE`
+return the same image output.
 
 ### `mocker stats`
 
@@ -1330,7 +1335,13 @@ Remove all stopped containers.
 
 ### `mocker image inspect`
 
-Display detailed information on one or more images.
+Display Docker-compatible detailed information on one or more images.
+
+```
+mocker image inspect [OPTIONS] IMAGE [IMAGE...]
+```
+
+Always returns a JSON array using Docker `ImageInspect` field names.
 
 | Flag | Short | Description |
 |------|-------|-------------|

--- a/Package.swift
+++ b/Package.swift
@@ -40,7 +40,8 @@ let package = Package(
         // Tests
         .testTarget(
             name: "MockerKitTests",
-            dependencies: ["MockerKit"]
+            dependencies: ["MockerKit"],
+            resources: [.copy("Fixtures")]
         ),
         .testTarget(
             name: "MockerTests",

--- a/README.md
+++ b/README.md
@@ -239,8 +239,12 @@ emulation is a workaround until upstream lands.
 # Inspect container (JSON output)
 mocker inspect myapp
 
-# Inspect multiple targets
+# Inspect multiple targets, or constrain discovery by type
 mocker inspect container1 container2 alpine:latest
+mocker inspect --type image alpine:latest
+
+# Docker-compatible ImageInspect JSON array; select a platform when needed
+mocker image inspect --platform linux/amd64 alpine:latest
 
 # Resource usage stats
 mocker stats --no-stream

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -181,8 +181,12 @@ mocker push my-registry.io/myapp:latest
 # 检查容器（JSON 输出）
 mocker inspect myapp
 
-# 同时检查多个对象
+# 同时检查多个对象，或按类型限定
 mocker inspect container1 container2 alpine:latest
+mocker inspect --type image alpine:latest
+
+# Docker 兼容的 ImageInspect JSON 数组；需要时指定平台
+mocker image inspect --platform linux/amd64 alpine:latest
 
 # 资源使用统计
 mocker stats --no-stream

--- a/Sources/Mocker/Commands/History.swift
+++ b/Sources/Mocker/Commands/History.swift
@@ -1,5 +1,6 @@
 import ArgumentParser
 import MockerKit
+import Foundation
 
 struct History: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
@@ -27,22 +28,68 @@ struct History: AsyncParsableCommand {
     func run() async throws {
         let config = MockerConfig()
         let manager = try ImageManager(config: config)
-        let info = try await manager.inspect(image)
+        let info = try await manager.inspect(image, platform: platform)
+
+        let shortID = String(info.id.prefix(12))
+        let sizeString = ByteCountFormatter.string(fromByteCount: info.size, countStyle: .file)
+        let createdAgo = info.created.map { RelativeDate.humanRelative($0) } ?? "N/A"
 
         if quiet {
-            print(noTrunc ? info.id : info.shortID)
+            print(noTrunc ? info.id : shortID)
             return
         }
 
         // Simplified history — show single layer since we don't have full layer info
         let headers = ["IMAGE", "CREATED", "CREATED BY", "SIZE", "COMMENT"]
         let rows = [[
-            noTrunc ? info.id : info.shortID,
-            info.createdAgo,
+            noTrunc ? info.id : shortID,
+            createdAgo,
             "",
-            info.sizeString,
+            sizeString,
             "",
         ]]
         TableFormatter.print(headers: headers, rows: rows)
+    }
+}
+
+/// Parses OCI `created` timestamps and renders them as human-relative dates.
+///
+/// `ISO8601DateFormatter` only understands millisecond fractions, so OCI configs
+/// carrying nanosecond precision (e.g. `2024-11-19T17:01:02.000000000Z`) fail to
+/// parse and previously fell back to the raw string. This helper tolerates variable
+/// fractional precision, including 9-digit nanoseconds.
+enum RelativeDate {
+    /// Parses an RFC3339 / RFC3339Nano timestamp into a `Date`, or `nil` if unparseable.
+    static func parse(_ string: String) -> Date? {
+        let fractional = ISO8601DateFormatter()
+        fractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = fractional.date(from: string) { return date }
+
+        let plain = ISO8601DateFormatter()
+        plain.formatOptions = [.withInternetDateTime]
+        if let date = plain.date(from: string) { return date }
+
+        // Last resort: strip an over-precise fractional component and retry.
+        if let stripped = stripFractionalSeconds(string) {
+            return plain.date(from: stripped)
+        }
+        return nil
+    }
+
+    /// Renders the timestamp as an abbreviated relative date, falling back to the
+    /// raw string only when it cannot be parsed.
+    static func humanRelative(_ string: String, relativeTo now: Date = Date()) -> String {
+        guard let date = parse(string) else { return string }
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        return formatter.localizedString(for: date, relativeTo: now)
+    }
+
+    /// Removes the fractional-seconds component, preserving the timezone designator.
+    private static func stripFractionalSeconds(_ string: String) -> String? {
+        guard let dot = string.firstIndex(of: ".") else { return nil }
+        let afterDot = string[string.index(after: dot)...]
+        let timezone = afterDot.firstIndex { !$0.isNumber }.map { String(afterDot[$0...]) } ?? ""
+        return String(string[string.startIndex..<dot]) + timezone
     }
 }

--- a/Sources/Mocker/Commands/ImageInspect.swift
+++ b/Sources/Mocker/Commands/ImageInspect.swift
@@ -1,6 +1,5 @@
 import ArgumentParser
 import MockerKit
-import Foundation
 
 struct ImageInspect: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
@@ -17,16 +16,15 @@ struct ImageInspect: AsyncParsableCommand {
     @Option(name: .long, help: "Inspect a specific platform of the multi-platform image")
     var platform: String?
 
-    func run() async throws {
-        let config = MockerConfig()
-        let manager = try ImageManager(config: config)
+    // MARK: - Run
 
+    func run() async throws {
+        let manager = try ImageManager(config: MockerConfig())
+        var results: [MockerKit.ImageInspect] = []
         for image in images {
-            let info = try await manager.inspect(image)
-            let encoder = JSONEncoder()
-            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-            let data = try encoder.encode(info)
-            print(String(data: data, encoding: .utf8) ?? "")
+            let info = try await manager.inspect(image, platform: platform)
+            results.append(info)
         }
+        try TableFormatter.printJSONArray(results, escapeSlashes: false)
     }
 }

--- a/Sources/Mocker/Commands/Inspect.swift
+++ b/Sources/Mocker/Commands/Inspect.swift
@@ -1,6 +1,11 @@
 import ArgumentParser
 import MockerKit
 
+enum InspectObjectType: String, ExpressibleByArgument {
+    case image
+    case container
+}
+
 struct Inspect: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         abstract: "Return low-level information on container or image"
@@ -13,7 +18,7 @@ struct Inspect: AsyncParsableCommand {
     var format: String?
 
     @Option(name: .long, help: "Only inspect objects of the given type (image or container)")
-    var type: String?
+    var type: InspectObjectType?
 
     @Option(name: .long, help: "Inspect a specific platform of a multi-platform image")
     var platform: String?
@@ -30,11 +35,11 @@ struct Inspect: AsyncParsableCommand {
 
     /// Single source of truth mapping the `--type` flag to an inspection target.
     /// Pure and injectable so routing can be unit-tested without runtime state.
-    static func resolveKind(type: String?) -> Kind {
+    static func resolveKind(type: InspectObjectType?) -> Kind {
         switch type {
-        case "image": return .image
-        case "container": return .container
-        default: return .auto
+        case .image: return .image
+        case .container: return .container
+        case nil: return .auto
         }
     }
 
@@ -69,10 +74,16 @@ struct Inspect: AsyncParsableCommand {
             for target in targets {
                 if let container = try? await engine.inspect(target) {
                     try TableFormatter.printJSONArray(container)
-                } else if let image = try? await imageManager.inspect(target) {
-                    try TableFormatter.printJSONArray(image, escapeSlashes: false)
                 } else {
-                    throw MockerError.containerNotFound(target)
+                    do {
+                        let image = try await imageManager.inspect(target, platform: platform)
+                        try TableFormatter.printJSONArray(image, escapeSlashes: false)
+                    } catch {
+                        if platform != nil {
+                            throw error
+                        }
+                        throw MockerError.containerNotFound(target)
+                    }
                 }
             }
         }

--- a/Sources/Mocker/Commands/Inspect.swift
+++ b/Sources/Mocker/Commands/Inspect.swift
@@ -12,11 +12,33 @@ struct Inspect: AsyncParsableCommand {
     @Option(name: .shortAndLong, help: "Format output using a custom template")
     var format: String?
 
-    @Option(name: .long, help: "Only inspect objects of the given type")
+    @Option(name: .long, help: "Only inspect objects of the given type (image or container)")
     var type: String?
+
+    @Option(name: .long, help: "Inspect a specific platform of a multi-platform image")
+    var platform: String?
 
     @Flag(name: .shortAndLong, help: "Display total file sizes if the type is container")
     var size = false
+
+    /// The resolved inspection target derived from `--type`.
+    enum Kind: Equatable {
+        case image
+        case container
+        case auto
+    }
+
+    /// Single source of truth mapping the `--type` flag to an inspection target.
+    /// Pure and injectable so routing can be unit-tested without runtime state.
+    static func resolveKind(type: String?) -> Kind {
+        switch type {
+        case "image": return .image
+        case "container": return .container
+        default: return .auto
+        }
+    }
+
+    // MARK: - Run
 
     func run() async throws {
         let config = MockerConfig()
@@ -25,14 +47,33 @@ struct Inspect: AsyncParsableCommand {
         let engine = try ContainerEngine(config: config)
         let imageManager = try ImageManager(config: config)
 
-        for target in targets {
-            // Try container first, then image
-            if let container = try? await engine.inspect(target) {
+        switch Self.resolveKind(type: type) {
+        case .image:
+            var results: [MockerKit.ImageInspect] = []
+            for target in targets {
+                let info = try await imageManager.inspect(target, platform: platform)
+                results.append(info)
+            }
+            try TableFormatter.printJSONArray(results, escapeSlashes: false)
+
+        case .container:
+            for target in targets {
+                guard let container = try? await engine.inspect(target) else {
+                    throw MockerError.containerNotFound(target)
+                }
                 try TableFormatter.printJSONArray(container)
-            } else if let image = try? await imageManager.inspect(target) {
-                try TableFormatter.printJSONArray(image)
-            } else {
-                throw MockerError.containerNotFound(target)
+            }
+
+        case .auto:
+            // Container-first fallback when --type is not specified
+            for target in targets {
+                if let container = try? await engine.inspect(target) {
+                    try TableFormatter.printJSONArray(container)
+                } else if let image = try? await imageManager.inspect(target) {
+                    try TableFormatter.printJSONArray(image, escapeSlashes: false)
+                } else {
+                    throw MockerError.containerNotFound(target)
+                }
             }
         }
     }

--- a/Sources/Mocker/Formatters/TableFormatter.swift
+++ b/Sources/Mocker/Formatters/TableFormatter.swift
@@ -30,11 +30,26 @@ enum TableFormatter {
     }
 
     /// Format a JSON-encodable value as pretty-printed JSON array (Docker inspect format).
-    static func printJSONArray<T: Encodable>(_ value: T) throws {
+    /// Wraps the single value in an array — identical output to `printJSONArray([value])`.
+    ///
+    /// - Parameter escapeSlashes: when `false`, emits `/` unescaped to match Docker's
+    ///   image inspect output. Defaults to `true` to preserve existing behavior.
+    static func printJSONArray<T: Encodable>(_ value: T, escapeSlashes: Bool = true) throws {
+        try printJSONArray([value], escapeSlashes: escapeSlashes)
+    }
+
+    /// Format a collection of JSON-encodable values as one pretty-printed JSON array.
+    /// Preserves input order. Required for multi-ref inspect to emit one `[…]` array.
+    ///
+    /// - Parameter escapeSlashes: when `false`, emits `/` unescaped to match Docker's
+    ///   image inspect output. Defaults to `true` to preserve existing behavior.
+    static func printJSONArray<T: Encodable>(_ values: [T], escapeSlashes: Bool = true) throws {
         let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        var formatting: JSONEncoder.OutputFormatting = [.prettyPrinted, .sortedKeys]
+        if !escapeSlashes { formatting.insert(.withoutEscapingSlashes) }
+        encoder.outputFormatting = formatting
         encoder.dateEncodingStrategy = .iso8601
-        let data = try encoder.encode([value])
+        let data = try encoder.encode(values)
         if let json = String(data: data, encoding: .utf8) {
             Swift.print(json)
         }

--- a/Sources/MockerKit/Image/ImageManager.swift
+++ b/Sources/MockerKit/Image/ImageManager.swift
@@ -117,9 +117,12 @@ public actor ImageManager {
 
         let manifest: ContainerizationOCI.Manifest
         let config: ContainerizationOCI.Image
+        let configExtras: ImageInspectConfigExtras
         if let matched = try? await image.manifest(for: resolvedPlatform) {
             manifest = matched
-            config = try await image.config(for: resolvedPlatform)
+            let configContent = try await image.getContent(digest: matched.config.digest)
+            config = try configContent.decode()
+            configExtras = try decodeImageInspectConfigExtras(from: configContent.data())
         } else {
             // No exact platform match: a single-arch or sole-manifest image is still
             // inspectable — Docker returns its only manifest. Multi-manifest indexes
@@ -130,9 +133,73 @@ public actor ImageManager {
                     "platform \(resolvedPlatform.description) not available for image \(reference)")
             }
             manifest = try await image.getContent(digest: sole.digest).decode()
-            config = try await image.getContent(digest: manifest.config.digest).decode()
+            let configContent = try await image.getContent(digest: manifest.config.digest)
+            config = try configContent.decode()
+            configExtras = try decodeImageInspectConfigExtras(from: configContent.data())
         }
-        return mapToImageInspect(config: config, manifest: manifest, reference: normalized, indexDigest: image.digest)
+        let repoMetadata = await repoMetadata(for: image, fallbackReference: normalized)
+        return mapToImageInspect(
+            config: config,
+            manifest: manifest,
+            reference: normalized,
+            indexDigest: image.digest,
+            configExtras: configExtras,
+            repoTags: repoMetadata.tags,
+            repoDigests: repoMetadata.digests
+        )
+    }
+
+    private func repoMetadata(
+        for image: Containerization.Image,
+        fallbackReference: String
+    ) async -> (tags: [String], digests: [String]) {
+        let images = (try? await imageStore.list()) ?? [image]
+        return Self.repoMetadata(for: image, localImages: images, fallbackReference: fallbackReference)
+    }
+
+    static func repoMetadata(
+        for image: Containerization.Image,
+        localImages images: [Containerization.Image],
+        fallbackReference: String
+    ) -> (tags: [String], digests: [String]) {
+        let matchingReferences = images
+            .filter { $0.digest == image.digest }
+            .map(\.reference)
+            .sorted()
+        let references = matchingReferences.isEmpty ? [image.reference, fallbackReference] : matchingReferences
+
+        let tags = Set(references.compactMap(Self.repoTag(from:))).sorted()
+        // Containerization exposes local references and the image's root descriptor digest,
+        // but not a registry-provided list of repo digest aliases. Report only repos found
+        // in local references that point at this exact stored descriptor.
+        let digests = Set(references.map { "\(Self.repositoryName(from: $0))@\(image.digest)" })
+            .sorted()
+
+        return (tags, digests)
+    }
+
+    private static func referenceHasTag(_ reference: String) -> Bool {
+        let beforeDigest = reference.split(separator: "@", maxSplits: 1).first.map(String.init) ?? reference
+        let lastComponent = beforeDigest
+            .split(separator: "/", omittingEmptySubsequences: false)
+            .last
+            .map(String.init) ?? beforeDigest
+        return lastComponent.contains(":")
+    }
+
+    private static func repoTag(from reference: String) -> String? {
+        let beforeDigest = reference.split(separator: "@", maxSplits: 1).first.map(String.init) ?? reference
+        return referenceHasTag(beforeDigest) ? beforeDigest : nil
+    }
+
+    private static func repositoryName(from reference: String) -> String {
+        let withoutDigest = reference.split(separator: "@", maxSplits: 1).first.map(String.init) ?? reference
+        var parts = withoutDigest.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+        if var last = parts.last, let colonIndex = last.lastIndex(of: ":") {
+            last = String(last[last.startIndex..<colonIndex])
+            parts[parts.count - 1] = last
+        }
+        return parts.joined(separator: "/")
     }
 
     /// Returns the only manifest descriptor when an index has exactly one, enabling
@@ -298,4 +365,3 @@ public actor ImageManager {
         )
     }
 }
-

--- a/Sources/MockerKit/Image/ImageManager.swift
+++ b/Sources/MockerKit/Image/ImageManager.swift
@@ -102,13 +102,46 @@ public actor ImageManager {
 
     // MARK: - Inspect
 
-    /// Inspect an image.
-    public func inspect(_ reference: String) async throws -> ImageInfo {
+    /// Inspect an image reference, returning a Docker-compatible ImageInspect.
+    public func inspect(_ reference: String, platform: String? = nil) async throws -> ImageInspect {
         let normalized = try Self.normalize(reference)
         guard let image = try? await imageStore.get(reference: normalized) else {
             throw MockerError.imageNotFound(reference)
         }
-        return Self.toImageInfo(image)
+        let resolvedPlatform: ContainerizationOCI.Platform
+        if let platformString = platform {
+            resolvedPlatform = try ContainerizationOCI.Platform(from: platformString)
+        } else {
+            resolvedPlatform = ContainerizationOCI.Platform.current
+        }
+
+        let manifest: ContainerizationOCI.Manifest
+        let config: ContainerizationOCI.Image
+        if let matched = try? await image.manifest(for: resolvedPlatform) {
+            manifest = matched
+            config = try await image.config(for: resolvedPlatform)
+        } else {
+            // No exact platform match: a single-arch or sole-manifest image is still
+            // inspectable — Docker returns its only manifest. Multi-manifest indexes
+            // with no match remain a genuine error.
+            let index = try await image.index()
+            guard let sole = Self.soleManifestDescriptor(from: index.manifests) else {
+                throw MockerError.operationFailed(
+                    "platform \(resolvedPlatform.description) not available for image \(reference)")
+            }
+            manifest = try await image.getContent(digest: sole.digest).decode()
+            config = try await image.getContent(digest: manifest.config.digest).decode()
+        }
+        return mapToImageInspect(config: config, manifest: manifest, reference: normalized, indexDigest: image.digest)
+    }
+
+    /// Returns the only manifest descriptor when an index has exactly one, enabling
+    /// single-arch images to be inspected even if their platform differs from the
+    /// requested one. Returns nil for empty or multi-manifest indexes.
+    static func soleManifestDescriptor(
+        from manifests: [ContainerizationOCI.Descriptor]
+    ) -> ContainerizationOCI.Descriptor? {
+        manifests.count == 1 ? manifests.first : nil
     }
 
     // MARK: - Build

--- a/Sources/MockerKit/Models/ImageInspect.swift
+++ b/Sources/MockerKit/Models/ImageInspect.swift
@@ -36,6 +36,34 @@ public struct ImageInspect: Codable, Sendable {
     /// Always emitted; an empty object `{}` for config-less images (Docker parity).
     public let config: ImageInspectConfig
     public let rootFS: ImageInspectRootFS
+
+    public init(
+        id: String,
+        repoTags: [String],
+        repoDigests: [String],
+        created: String? = nil,
+        author: String? = nil,
+        architecture: String,
+        variant: String? = nil,
+        os: String,
+        osVersion: String? = nil,
+        size: Int64,
+        config: ImageInspectConfig,
+        rootFS: ImageInspectRootFS
+    ) {
+        self.id = id
+        self.repoTags = repoTags
+        self.repoDigests = repoDigests
+        self.created = created
+        self.author = author
+        self.architecture = architecture
+        self.variant = variant
+        self.os = os
+        self.osVersion = osVersion
+        self.size = size
+        self.config = config
+        self.rootFS = rootFS
+    }
 }
 
 /// Docker-compatible Config sub-object. All fields are optional; absent fields are omitted.
@@ -44,8 +72,10 @@ public struct ImageInspectConfig: Codable, Sendable {
     enum CodingKeys: String, CodingKey {
         case user = "User"
         case env = "Env"
+        case exposedPorts = "ExposedPorts"
         case entrypoint = "Entrypoint"
         case cmd = "Cmd"
+        case volumes = "Volumes"
         case workingDir = "WorkingDir"
         case labels = "Labels"
         case stopSignal = "StopSignal"
@@ -53,8 +83,10 @@ public struct ImageInspectConfig: Codable, Sendable {
 
     public let user: String?
     public let env: [String]?
+    public let exposedPorts: [String: ImageInspectEmptyObject]?
     public let entrypoint: [String]?
     public let cmd: [String]?
+    public let volumes: [String: ImageInspectEmptyObject]?
     public let workingDir: String?
     public let labels: [String: String]?
     public let stopSignal: String?
@@ -62,19 +94,42 @@ public struct ImageInspectConfig: Codable, Sendable {
     public init(
         user: String? = nil,
         env: [String]? = nil,
+        exposedPorts: [String: ImageInspectEmptyObject]? = nil,
         entrypoint: [String]? = nil,
         cmd: [String]? = nil,
+        volumes: [String: ImageInspectEmptyObject]? = nil,
         workingDir: String? = nil,
         labels: [String: String]? = nil,
         stopSignal: String? = nil
     ) {
         self.user = user
         self.env = env
+        self.exposedPorts = exposedPorts
         self.entrypoint = entrypoint
         self.cmd = cmd
+        self.volumes = volumes
         self.workingDir = workingDir
         self.labels = labels
         self.stopSignal = stopSignal
+    }
+}
+
+/// Encodes Docker's map[string]struct{} values, for example `"80/tcp": {}`.
+public struct ImageInspectEmptyObject: Codable, Sendable, Equatable {
+    public init() {}
+}
+
+/// Extra config fields not currently surfaced by ContainerizationOCI.ImageConfig.
+public struct ImageInspectConfigExtras: Codable, Sendable, Equatable {
+    public let exposedPorts: [String: ImageInspectEmptyObject]?
+    public let volumes: [String: ImageInspectEmptyObject]?
+
+    public init(
+        exposedPorts: [String: ImageInspectEmptyObject]? = nil,
+        volumes: [String: ImageInspectEmptyObject]? = nil
+    ) {
+        self.exposedPorts = exposedPorts
+        self.volumes = volumes
     }
 }
 
@@ -88,6 +143,11 @@ public struct ImageInspectRootFS: Codable, Sendable {
     public let type: String
     /// Equals OCI config rootfs.diff_ids.
     public let layers: [String]
+
+    public init(type: String, layers: [String]) {
+        self.type = type
+        self.layers = layers
+    }
 }
 
 // MARK: - Pure Mapping Function
@@ -99,34 +159,48 @@ public struct ImageInspectRootFS: Codable, Sendable {
 ///   - manifest: Decoded OCI image manifest for the resolved platform.
 ///   - reference: Fully-qualified image reference (e.g. `docker.io/library/nginx:latest`).
 ///   - indexDigest: Index (multi-arch) digest used for `RepoDigests` (`image.digest`).
+///   - configExtras: Config fields decoded from the raw OCI config JSON but not exposed
+///     by `ContainerizationOCI.ImageConfig`.
+///   - overrideRepoTags: Local image-store tags to report. When absent, derived from
+///     `reference` for compatibility with pure mapping tests.
+///   - overrideRepoDigests: Local image-store repo digests to report. When absent,
+///     derived from `reference` for compatibility with pure mapping tests.
 /// - Returns: A populated `ImageInspect` ready for JSON serialisation.
 public func mapToImageInspect(
     config: ContainerizationOCI.Image,
     manifest: ContainerizationOCI.Manifest,
     reference: String,
-    indexDigest: String
+    indexDigest: String,
+    configExtras: ImageInspectConfigExtras? = nil,
+    repoTags overrideRepoTags: [String]? = nil,
+    repoDigests overrideRepoDigests: [String]? = nil
 ) -> ImageInspect {
     // Id is the config blob digest, not the index digest — Docker parity for single-platform inspect.
     let id = manifest.config.digest
 
     let size = manifest.layers.reduce(0) { $0 + $1.size } + manifest.config.size
 
-    let repoTags = extractRepoTags(from: reference)
+    let repoTags = overrideRepoTags ?? extractRepoTags(from: reference)
     let repo = extractRepo(from: reference)
-    let repoDigests = ["\(repo)@\(indexDigest)"]
+    let repoDigests = overrideRepoDigests ?? ["\(repo)@\(indexDigest)"]
 
     // Docker always emits Config; fall back to an empty object for config-less images.
     let inspectConfig = config.config.map { ociConfig in
         ImageInspectConfig(
             user: ociConfig.user,
             env: ociConfig.env,
+            exposedPorts: configExtras?.exposedPorts,
             entrypoint: ociConfig.entrypoint,
             cmd: ociConfig.cmd,
+            volumes: configExtras?.volumes,
             workingDir: ociConfig.workingDir,
             labels: ociConfig.labels,
             stopSignal: ociConfig.stopSignal
         )
-    } ?? ImageInspectConfig()
+    } ?? ImageInspectConfig(
+        exposedPorts: configExtras?.exposedPorts,
+        volumes: configExtras?.volumes
+    )
 
     let rootFS = ImageInspectRootFS(
         type: "layers",
@@ -146,6 +220,28 @@ public func mapToImageInspect(
         size: size,
         config: inspectConfig,
         rootFS: rootFS
+    )
+}
+
+func decodeImageInspectConfigExtras(from data: Data) throws -> ImageInspectConfigExtras {
+    struct RawImageConfig: Decodable {
+        struct RawConfig: Decodable {
+            enum CodingKeys: String, CodingKey {
+                case exposedPorts = "ExposedPorts"
+                case volumes = "Volumes"
+            }
+
+            let exposedPorts: [String: ImageInspectEmptyObject]?
+            let volumes: [String: ImageInspectEmptyObject]?
+        }
+
+        let config: RawConfig?
+    }
+
+    let raw = try JSONDecoder().decode(RawImageConfig.self, from: data)
+    return ImageInspectConfigExtras(
+        exposedPorts: raw.config?.exposedPorts,
+        volumes: raw.config?.volumes
     )
 }
 

--- a/Sources/MockerKit/Models/ImageInspect.swift
+++ b/Sources/MockerKit/Models/ImageInspect.swift
@@ -1,0 +1,190 @@
+import Foundation
+import ContainerizationOCI
+
+// MARK: - Docker-Compatible ImageInspect DTOs
+
+/// Docker-compatible image inspect output (mirrors `moby/moby` ImageInspect struct).
+/// Serializes with Docker PascalCase JSON keys; optional fields are omitted when absent.
+public struct ImageInspect: Codable, Sendable {
+    enum CodingKeys: String, CodingKey {
+        case id = "Id"
+        case repoTags = "RepoTags"
+        case repoDigests = "RepoDigests"
+        case created = "Created"
+        case author = "Author"
+        case architecture = "Architecture"
+        case variant = "Variant"
+        case os = "Os"
+        case osVersion = "OsVersion"
+        case size = "Size"
+        case config = "Config"
+        case rootFS = "RootFS"
+    }
+
+    public let id: String
+    public let repoTags: [String]
+    public let repoDigests: [String]
+    /// RFC3339Nano pass-through from OCI config. Omitted when the OCI config has no created field.
+    public let created: String?
+    public let author: String?
+    public let architecture: String
+    public let variant: String?
+    public let os: String
+    public let osVersion: String?
+    /// Σ manifest layer sizes + config blob size (no blob reads).
+    public let size: Int64
+    /// Always emitted; an empty object `{}` for config-less images (Docker parity).
+    public let config: ImageInspectConfig
+    public let rootFS: ImageInspectRootFS
+}
+
+/// Docker-compatible Config sub-object. All fields are optional; absent fields are omitted.
+public struct ImageInspectConfig: Codable, Sendable {
+    // Explicit PascalCase CodingKeys mirror Docker's ImageConfig JSON contract.
+    enum CodingKeys: String, CodingKey {
+        case user = "User"
+        case env = "Env"
+        case entrypoint = "Entrypoint"
+        case cmd = "Cmd"
+        case workingDir = "WorkingDir"
+        case labels = "Labels"
+        case stopSignal = "StopSignal"
+    }
+
+    public let user: String?
+    public let env: [String]?
+    public let entrypoint: [String]?
+    public let cmd: [String]?
+    public let workingDir: String?
+    public let labels: [String: String]?
+    public let stopSignal: String?
+
+    public init(
+        user: String? = nil,
+        env: [String]? = nil,
+        entrypoint: [String]? = nil,
+        cmd: [String]? = nil,
+        workingDir: String? = nil,
+        labels: [String: String]? = nil,
+        stopSignal: String? = nil
+    ) {
+        self.user = user
+        self.env = env
+        self.entrypoint = entrypoint
+        self.cmd = cmd
+        self.workingDir = workingDir
+        self.labels = labels
+        self.stopSignal = stopSignal
+    }
+}
+
+/// Docker-compatible RootFS sub-object.
+public struct ImageInspectRootFS: Codable, Sendable {
+    enum CodingKeys: String, CodingKey {
+        case type = "Type"
+        case layers = "Layers"
+    }
+
+    public let type: String
+    /// Equals OCI config rootfs.diff_ids.
+    public let layers: [String]
+}
+
+// MARK: - Pure Mapping Function
+
+/// Maps OCI manifest + config to a Docker-compatible `ImageInspect`. Pure, no I/O.
+///
+/// - Parameters:
+///   - config: Decoded OCI image config (`application/vnd.oci.image.config.v1+json`).
+///   - manifest: Decoded OCI image manifest for the resolved platform.
+///   - reference: Fully-qualified image reference (e.g. `docker.io/library/nginx:latest`).
+///   - indexDigest: Index (multi-arch) digest used for `RepoDigests` (`image.digest`).
+/// - Returns: A populated `ImageInspect` ready for JSON serialisation.
+public func mapToImageInspect(
+    config: ContainerizationOCI.Image,
+    manifest: ContainerizationOCI.Manifest,
+    reference: String,
+    indexDigest: String
+) -> ImageInspect {
+    // Id is the config blob digest, not the index digest — Docker parity for single-platform inspect.
+    let id = manifest.config.digest
+
+    let size = manifest.layers.reduce(0) { $0 + $1.size } + manifest.config.size
+
+    let repoTags = extractRepoTags(from: reference)
+    let repo = extractRepo(from: reference)
+    let repoDigests = ["\(repo)@\(indexDigest)"]
+
+    // Docker always emits Config; fall back to an empty object for config-less images.
+    let inspectConfig = config.config.map { ociConfig in
+        ImageInspectConfig(
+            user: ociConfig.user,
+            env: ociConfig.env,
+            entrypoint: ociConfig.entrypoint,
+            cmd: ociConfig.cmd,
+            workingDir: ociConfig.workingDir,
+            labels: ociConfig.labels,
+            stopSignal: ociConfig.stopSignal
+        )
+    } ?? ImageInspectConfig()
+
+    let rootFS = ImageInspectRootFS(
+        type: "layers",
+        layers: config.rootfs.diffIDs
+    )
+
+    return ImageInspect(
+        id: id,
+        repoTags: repoTags,
+        repoDigests: repoDigests,
+        created: config.created,
+        author: config.author,
+        architecture: config.architecture,
+        variant: config.variant,
+        os: config.os,
+        osVersion: config.osVersion,
+        size: size,
+        config: inspectConfig,
+        rootFS: rootFS
+    )
+}
+
+// MARK: - Reference Parsing Helpers
+
+/// Returns the `repo:tag` portion for tagged references, or `[]` for pure digest references.
+private func extractRepoTags(from reference: String) -> [String] {
+    guard let atIndex = reference.firstIndex(of: "@") else {
+        return [reference]
+    }
+    // For digest references, RepoTags carries the tag portion before "@" (empty when untagged).
+    let beforeAt = String(reference[reference.startIndex..<atIndex])
+    return referenceHasTag(beforeAt) ? [beforeAt] : []
+}
+
+/// Detects a tag by looking for ":" in the last path component, ignoring registry host ports.
+private func referenceHasTag(_ reference: String) -> Bool {
+    let lastComponent = reference
+        .split(separator: "/", omittingEmptySubsequences: false)
+        .last
+        .map(String.init) ?? reference
+    return lastComponent.contains(":")
+}
+
+/// Extracts the repository portion of a reference (strips tag and digest).
+private func extractRepo(from reference: String) -> String {
+    // Strip digest suffix first
+    let withoutDigest: String
+    if let atIndex = reference.firstIndex(of: "@") {
+        withoutDigest = String(reference[reference.startIndex..<atIndex])
+    } else {
+        withoutDigest = reference
+    }
+    // Strip tag suffix — find last ":" that is not part of a port in a registry host
+    // Strategy: split by "/" and strip ":" from the last component only
+    var parts = withoutDigest.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+    if var last = parts.last, let colonIndex = last.lastIndex(of: ":") {
+        last = String(last[last.startIndex..<colonIndex])
+        parts[parts.count - 1] = last
+    }
+    return parts.joined(separator: "/")
+}

--- a/Tests/MockerKitTests/Fixtures/image-inspect/config.json
+++ b/Tests/MockerKitTests/Fixtures/image-inspect/config.json
@@ -1,0 +1,30 @@
+{
+  "architecture": "arm64",
+  "author": "NGINX Docker Maintainers",
+  "config": {
+    "Cmd": [
+      "nginx",
+      "-g",
+      "daemon off;"
+    ],
+    "Env": [
+      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+      "NGINX_VERSION=1.27.0"
+    ],
+    "Labels": {
+      "maintainer": "NGINX Docker Maintainers <docker-maint@nginx.com>"
+    },
+    "StopSignal": "SIGQUIT",
+    "WorkingDir": "/app"
+  },
+  "created": "2024-11-19T17:01:02.000000000Z",
+  "os": "linux",
+  "rootfs": {
+    "diff_ids": [
+      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    ],
+    "type": "layers"
+  },
+  "variant": "v8"
+}

--- a/Tests/MockerKitTests/Fixtures/image-inspect/config.json
+++ b/Tests/MockerKitTests/Fixtures/image-inspect/config.json
@@ -11,10 +11,18 @@
       "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
       "NGINX_VERSION=1.27.0"
     ],
+    "ExposedPorts": {
+      "443/tcp": {},
+      "80/tcp": {}
+    },
     "Labels": {
       "maintainer": "NGINX Docker Maintainers <docker-maint@nginx.com>"
     },
     "StopSignal": "SIGQUIT",
+    "Volumes": {
+      "/var/cache/nginx": {},
+      "/var/log/nginx": {}
+    },
     "WorkingDir": "/app"
   },
   "created": "2024-11-19T17:01:02.000000000Z",

--- a/Tests/MockerKitTests/Fixtures/image-inspect/expected.json
+++ b/Tests/MockerKitTests/Fixtures/image-inspect/expected.json
@@ -1,0 +1,38 @@
+{
+  "Architecture" : "arm64",
+  "Author" : "NGINX Docker Maintainers",
+  "Config" : {
+    "Cmd" : [
+      "nginx",
+      "-g",
+      "daemon off;"
+    ],
+    "Env" : [
+      "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+      "NGINX_VERSION=1.27.0"
+    ],
+    "Labels" : {
+      "maintainer" : "NGINX Docker Maintainers <docker-maint@nginx.com>"
+    },
+    "StopSignal" : "SIGQUIT",
+    "WorkingDir" : "/app"
+  },
+  "Created" : "2024-11-19T17:01:02.000000000Z",
+  "Id" : "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+  "Os" : "linux",
+  "RepoDigests" : [
+    "docker.io/library/nginx@sha256:indexdigest0000000000000000000000000000000000000000000000000000"
+  ],
+  "RepoTags" : [
+    "docker.io/library/nginx:latest"
+  ],
+  "RootFS" : {
+    "Layers" : [
+      "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    ],
+    "Type" : "layers"
+  },
+  "Size" : 4202136,
+  "Variant" : "v8"
+}

--- a/Tests/MockerKitTests/Fixtures/image-inspect/expected.json
+++ b/Tests/MockerKitTests/Fixtures/image-inspect/expected.json
@@ -11,10 +11,26 @@
       "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
       "NGINX_VERSION=1.27.0"
     ],
+    "ExposedPorts" : {
+      "443/tcp" : {
+
+      },
+      "80/tcp" : {
+
+      }
+    },
     "Labels" : {
       "maintainer" : "NGINX Docker Maintainers <docker-maint@nginx.com>"
     },
     "StopSignal" : "SIGQUIT",
+    "Volumes" : {
+      "/var/cache/nginx" : {
+
+      },
+      "/var/log/nginx" : {
+
+      }
+    },
     "WorkingDir" : "/app"
   },
   "Created" : "2024-11-19T17:01:02.000000000Z",

--- a/Tests/MockerKitTests/Fixtures/image-inspect/manifest.json
+++ b/Tests/MockerKitTests/Fixtures/image-inspect/manifest.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "config": {
+    "mediaType": "application/vnd.oci.image.config.v1+json",
+    "digest": "sha256:a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2",
+    "size": 7832
+  },
+  "layers": [
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "digest": "sha256:1111111111111111111111111111111111111111111111111111111111111111",
+      "size": 3145728
+    },
+    {
+      "mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+      "digest": "sha256:2222222222222222222222222222222222222222222222222222222222222222",
+      "size": 1048576
+    }
+  ]
+}

--- a/Tests/MockerKitTests/ImageInspectMappingTests.swift
+++ b/Tests/MockerKitTests/ImageInspectMappingTests.swift
@@ -1,0 +1,260 @@
+import Testing
+import Foundation
+import ContainerizationOCI
+@testable import MockerKit
+
+// MARK: - Helpers
+
+private func loadFixture(_ name: String) throws -> Data {
+    guard let url = Bundle.module.url(forResource: "Fixtures/image-inspect/\(name)", withExtension: nil) else {
+        throw MockerError.operationFailed("Fixture not found: \(name)")
+    }
+    return try Data(contentsOf: url)
+}
+
+private func decodeManifest() throws -> ContainerizationOCI.Manifest {
+    let data = try loadFixture("manifest.json")
+    return try JSONDecoder().decode(ContainerizationOCI.Manifest.self, from: data)
+}
+
+private func decodeConfig() throws -> ContainerizationOCI.Image {
+    let data = try loadFixture("config.json")
+    return try JSONDecoder().decode(ContainerizationOCI.Image.self, from: data)
+}
+
+private func makeEncoder() -> JSONEncoder {
+    let encoder = JSONEncoder()
+    // Mirror the image-inspect CLI path, which emits slashes unescaped (Docker parity).
+    encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+    return encoder
+}
+
+// MARK: - Test Suite
+
+@Suite("ImageInspect Mapping Tests")
+struct ImageInspectMappingTests {
+
+    // Reference constants used across tests
+    let taggedReference = "docker.io/library/nginx:latest"
+    let indexDigest = "sha256:indexdigest0000000000000000000000000000000000000000000000000000"
+
+    /// 2.1 — Golden fixture conformance: full byte-for-byte match against expected.json.
+    @Test("Golden fixture: mapToImageInspect matches expected.json byte-for-byte")
+    func goldenFixtureMatch() throws {
+        let manifest = try decodeManifest()
+        let config = try decodeConfig()
+        let expected = try loadFixture("expected.json")
+
+        let result = mapToImageInspect(
+            config: config,
+            manifest: manifest,
+            reference: taggedReference,
+            indexDigest: indexDigest
+        )
+
+        let encoded = try makeEncoder().encode(result)
+
+        // Normalize both to comparable strings for a legible diff on failure
+        let resultString = String(decoding: encoded, as: UTF8.self)
+        let expectedString = String(decoding: expected, as: UTF8.self)
+        #expect(resultString == expectedString)
+    }
+
+    /// 2.2 — Absent optional fields must be omitted (not null). Uses a minimal config with nil author.
+    @Test("Absent Author field is omitted from JSON output")
+    func absentAuthorOmitted() throws {
+        let manifest = try decodeManifest()
+        // Build a config with no author
+        let configNoAuthor = ContainerizationOCI.Image(
+            created: "2024-01-01T00:00:00Z",
+            author: nil,
+            architecture: "arm64",
+            os: "linux",
+            rootfs: ContainerizationOCI.Rootfs(type: "layers", diffIDs: ["sha256:aaa"])
+        )
+
+        let result = mapToImageInspect(
+            config: configNoAuthor,
+            manifest: manifest,
+            reference: taggedReference,
+            indexDigest: indexDigest
+        )
+
+        let encoded = try makeEncoder().encode(result)
+        let json = String(decoding: encoded, as: UTF8.self)
+        #expect(!json.contains("\"Author\""))
+    }
+
+    /// 2.3 — Digest-only reference must produce RepoTags == [] (present, not omitted).
+    @Test("Digest-only reference produces empty RepoTags array")
+    func digestOnlyReferenceEmptyRepoTags() throws {
+        let manifest = try decodeManifest()
+        let config = try decodeConfig()
+        let digestOnlyRef = "docker.io/library/nginx@sha256:indexdigest0000000000000000000000000000000000000000000000000000"
+
+        let result = mapToImageInspect(
+            config: config,
+            manifest: manifest,
+            reference: digestOnlyRef,
+            indexDigest: indexDigest
+        )
+
+        #expect(result.repoTags == [])
+        let encoded = try makeEncoder().encode(result)
+        let json = String(decoding: encoded, as: UTF8.self)
+        // Key must still be present as empty array
+        #expect(json.contains("\"RepoTags\" : ["))
+    }
+
+    /// 2.3b — Tag+digest reference must keep the `repo:tag` portion (everything before "@").
+    @Test("Tag+digest reference produces RepoTags with the repo:tag portion")
+    func tagAndDigestReferenceKeepsRepoTag() throws {
+        let manifest = try decodeManifest()
+        let config = try decodeConfig()
+        let tagAndDigestRef = "docker.io/library/nginx:latest@sha256:indexdigest0000000000000000000000000000000000000000000000000000"
+
+        let result = mapToImageInspect(
+            config: config,
+            manifest: manifest,
+            reference: tagAndDigestRef,
+            indexDigest: indexDigest
+        )
+
+        #expect(result.repoTags == ["docker.io/library/nginx:latest"])
+    }
+
+    /// 2.3c — Pure digest reference (no tag) must produce RepoTags == [].
+    @Test("Pure digest reference produces empty RepoTags array")
+    func pureDigestReferenceEmptyRepoTags() throws {
+        let manifest = try decodeManifest()
+        let config = try decodeConfig()
+        let pureDigestRef = "docker.io/library/nginx@sha256:indexdigest0000000000000000000000000000000000000000000000000000"
+
+        let result = mapToImageInspect(
+            config: config,
+            manifest: manifest,
+            reference: pureDigestRef,
+            indexDigest: indexDigest
+        )
+
+        #expect(result.repoTags == [])
+    }
+
+    /// 2.4 — Created must pass through as-is (RFC3339Nano string, not Double, not reformatted).
+    @Test("Created is serialized as raw RFC3339Nano string, not a number")
+    func createdPassThrough() throws {
+        let manifest = try decodeManifest()
+        let config = try decodeConfig()
+        let expectedCreated = "2024-11-19T17:01:02.000000000Z"
+
+        let result = mapToImageInspect(
+            config: config,
+            manifest: manifest,
+            reference: taggedReference,
+            indexDigest: indexDigest
+        )
+
+        #expect(result.created == expectedCreated)
+        let encoded = try makeEncoder().encode(result)
+        let json = String(decoding: encoded, as: UTF8.self)
+        #expect(json.contains("\"Created\" : \"\(expectedCreated)\""))
+    }
+
+    /// 2.5 — Size must equal Σ manifest.layers[].size + manifest.config.size (no blob reads).
+    @Test("Size equals sum of manifest layer sizes plus config size")
+    func sizeComputation() throws {
+        let manifest = try decodeManifest()
+        let config = try decodeConfig()
+
+        // Derived from fixture: layer1=3145728 + layer2=1048576 + config=7832 = 4202136
+        let expectedSize: Int64 = 4202136
+
+        let result = mapToImageInspect(
+            config: config,
+            manifest: manifest,
+            reference: taggedReference,
+            indexDigest: indexDigest
+        )
+
+        #expect(result.size == expectedSize)
+    }
+
+    /// 2.6 — RootFS.Layers must equal rootfs.diff_ids; Type must be "layers".
+    @Test("RootFS.Layers matches OCI rootfs.diff_ids and Type is 'layers'")
+    func rootFSMapping() throws {
+        let manifest = try decodeManifest()
+        let config = try decodeConfig()
+        let expectedLayers = [
+            "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+        ]
+
+        let result = mapToImageInspect(
+            config: config,
+            manifest: manifest,
+            reference: taggedReference,
+            indexDigest: indexDigest
+        )
+
+        #expect(result.rootFS.type == "layers")
+        #expect(result.rootFS.layers == expectedLayers)
+    }
+
+    /// 2.7 — Config sub-object must use Docker PascalCase keys and mirror OCI config values.
+    @Test("Config sub-object uses Docker PascalCase keys and mirrors OCI config values")
+    func configMapping() throws {
+        let manifest = try decodeManifest()
+        let config = try decodeConfig()
+
+        let result = mapToImageInspect(
+            config: config,
+            manifest: manifest,
+            reference: taggedReference,
+            indexDigest: indexDigest
+        )
+
+        let cfg = result.config
+        #expect(cfg.cmd == ["nginx", "-g", "daemon off;"])
+        #expect(cfg.env == [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "NGINX_VERSION=1.27.0",
+        ])
+        #expect(cfg.workingDir == "/app")
+        #expect(cfg.stopSignal == "SIGQUIT")
+        #expect(cfg.labels == ["maintainer": "NGINX Docker Maintainers <docker-maint@nginx.com>"])
+        // Encoded keys must be PascalCase
+        let encoded = try makeEncoder().encode(result)
+        let json = String(decoding: encoded, as: UTF8.self)
+        #expect(json.contains("\"Cmd\""))
+        #expect(json.contains("\"Env\""))
+        #expect(json.contains("\"WorkingDir\""))
+        #expect(json.contains("\"StopSignal\""))
+        #expect(json.contains("\"Labels\""))
+    }
+
+    /// 2.8 — Config is always emitted; a config-less image yields `"Config": {}` (Docker parity).
+    @Test("Config key is present as empty object when OCI config sub-object is absent")
+    func configAbsentEmptyObject() throws {
+        let manifest = try decodeManifest()
+        let configNoConfig = ContainerizationOCI.Image(
+            created: "2024-01-01T00:00:00Z",
+            architecture: "arm64",
+            os: "linux",
+            config: nil,
+            rootfs: ContainerizationOCI.Rootfs(type: "layers", diffIDs: ["sha256:aaa"])
+        )
+
+        let result = mapToImageInspect(
+            config: configNoConfig,
+            manifest: manifest,
+            reference: taggedReference,
+            indexDigest: indexDigest
+        )
+
+        let encoded = try makeEncoder().encode(result)
+        let json = String(decoding: encoded, as: UTF8.self)
+        #expect(json.contains("\"Config\" : {"))
+        #expect(result.config.cmd == nil)
+        #expect(result.config.env == nil)
+    }
+}

--- a/Tests/MockerKitTests/ImageInspectMappingTests.swift
+++ b/Tests/MockerKitTests/ImageInspectMappingTests.swift
@@ -22,11 +22,20 @@ private func decodeConfig() throws -> ContainerizationOCI.Image {
     return try JSONDecoder().decode(ContainerizationOCI.Image.self, from: data)
 }
 
+private func decodeConfigExtras() throws -> ImageInspectConfigExtras {
+    try decodeImageInspectConfigExtras(from: loadFixture("config.json"))
+}
+
 private func makeEncoder() -> JSONEncoder {
     let encoder = JSONEncoder()
     // Mirror the image-inspect CLI path, which emits slashes unescaped (Docker parity).
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
     return encoder
+}
+
+private func withoutSingleTrailingNewline(_ string: String) -> String {
+    guard string.hasSuffix("\n") else { return string }
+    return String(string.dropLast())
 }
 
 // MARK: - Test Suite
@@ -49,14 +58,15 @@ struct ImageInspectMappingTests {
             config: config,
             manifest: manifest,
             reference: taggedReference,
-            indexDigest: indexDigest
+            indexDigest: indexDigest,
+            configExtras: try decodeConfigExtras()
         )
 
         let encoded = try makeEncoder().encode(result)
 
         // Normalize both to comparable strings for a legible diff on failure
         let resultString = String(decoding: encoded, as: UTF8.self)
-        let expectedString = String(decoding: expected, as: UTF8.self)
+        let expectedString = withoutSingleTrailingNewline(String(decoding: expected, as: UTF8.self))
         #expect(resultString == expectedString)
     }
 
@@ -140,6 +150,25 @@ struct ImageInspectMappingTests {
         #expect(result.repoTags == [])
     }
 
+    @Test("Explicit local repo metadata overrides reference-derived fallback")
+    func explicitRepoMetadataOverridesFallback() throws {
+        let manifest = try decodeManifest()
+        let config = try decodeConfig()
+        let localDigest = "sha256:localdigest000000000000000000000000000000000000000000000000000"
+
+        let result = mapToImageInspect(
+            config: config,
+            manifest: manifest,
+            reference: "docker.io/library/not-the-local-alias:latest",
+            indexDigest: indexDigest,
+            repoTags: ["registry.example.com/prod/nginx:stable"],
+            repoDigests: ["registry.example.com/prod/nginx@\(localDigest)"]
+        )
+
+        #expect(result.repoTags == ["registry.example.com/prod/nginx:stable"])
+        #expect(result.repoDigests == ["registry.example.com/prod/nginx@\(localDigest)"])
+    }
+
     /// 2.4 — Created must pass through as-is (RFC3339Nano string, not Double, not reformatted).
     @Test("Created is serialized as raw RFC3339Nano string, not a number")
     func createdPassThrough() throws {
@@ -210,7 +239,8 @@ struct ImageInspectMappingTests {
             config: config,
             manifest: manifest,
             reference: taggedReference,
-            indexDigest: indexDigest
+            indexDigest: indexDigest,
+            configExtras: try decodeConfigExtras()
         )
 
         let cfg = result.config
@@ -219,17 +249,64 @@ struct ImageInspectMappingTests {
             "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
             "NGINX_VERSION=1.27.0",
         ])
+        #expect(cfg.exposedPorts == [
+            "443/tcp": ImageInspectEmptyObject(),
+            "80/tcp": ImageInspectEmptyObject(),
+        ])
         #expect(cfg.workingDir == "/app")
         #expect(cfg.stopSignal == "SIGQUIT")
         #expect(cfg.labels == ["maintainer": "NGINX Docker Maintainers <docker-maint@nginx.com>"])
+        #expect(cfg.volumes == [
+            "/var/cache/nginx": ImageInspectEmptyObject(),
+            "/var/log/nginx": ImageInspectEmptyObject(),
+        ])
         // Encoded keys must be PascalCase
         let encoded = try makeEncoder().encode(result)
         let json = String(decoding: encoded, as: UTF8.self)
         #expect(json.contains("\"Cmd\""))
         #expect(json.contains("\"Env\""))
+        #expect(json.contains("\"ExposedPorts\""))
         #expect(json.contains("\"WorkingDir\""))
         #expect(json.contains("\"StopSignal\""))
         #expect(json.contains("\"Labels\""))
+        #expect(json.contains("\"Volumes\""))
+    }
+
+    /// Current ContainerizationOCI.ImageConfig does not expose Docker's map[string]struct{}
+    /// config metadata. The raw fixture still contains it; callers must pass decoded extras
+    /// until the upstream model surfaces these fields directly.
+    @Test("Raw config extras preserve ExposedPorts and Volumes omitted by ContainerizationOCI")
+    func rawConfigExtrasPreserveDockerMetadata() throws {
+        let manifest = try decodeManifest()
+        let config = try decodeConfig()
+
+        let withoutExtras = mapToImageInspect(
+            config: config,
+            manifest: manifest,
+            reference: taggedReference,
+            indexDigest: indexDigest
+        )
+
+        #expect(withoutExtras.config.exposedPorts == nil)
+        #expect(withoutExtras.config.volumes == nil)
+
+        let extras = try decodeConfigExtras()
+        let withExtras = mapToImageInspect(
+            config: config,
+            manifest: manifest,
+            reference: taggedReference,
+            indexDigest: indexDigest,
+            configExtras: extras
+        )
+
+        #expect(withExtras.config.exposedPorts == [
+            "443/tcp": ImageInspectEmptyObject(),
+            "80/tcp": ImageInspectEmptyObject(),
+        ])
+        #expect(withExtras.config.volumes == [
+            "/var/cache/nginx": ImageInspectEmptyObject(),
+            "/var/log/nginx": ImageInspectEmptyObject(),
+        ])
     }
 
     /// 2.8 — Config is always emitted; a config-less image yields `"Config": {}` (Docker parity).

--- a/Tests/MockerKitTests/ImageManagerInspectTests.swift
+++ b/Tests/MockerKitTests/ImageManagerInspectTests.swift
@@ -1,0 +1,34 @@
+import Testing
+import Foundation
+import ContainerizationOCI
+@testable import MockerKit
+
+@Suite("ImageManager sole-manifest fallback")
+struct ImageManagerInspectTests {
+
+    private func descriptor(arch: String) -> ContainerizationOCI.Descriptor {
+        ContainerizationOCI.Descriptor(
+            mediaType: "application/vnd.oci.image.manifest.v1+json",
+            digest: "sha256:\(arch)0000000000000000000000000000000000000000000000000000000000",
+            size: 100,
+            platform: ContainerizationOCI.Platform(arch: arch, os: "linux")
+        )
+    }
+
+    @Test("single-manifest index returns its sole descriptor")
+    func singleManifestReturnsSole() {
+        let sole = descriptor(arch: "amd64")
+        #expect(ImageManager.soleManifestDescriptor(from: [sole]) == sole)
+    }
+
+    @Test("multi-manifest index returns nil (no implicit selection)")
+    func multiManifestReturnsNil() {
+        let manifests = [descriptor(arch: "amd64"), descriptor(arch: "arm64")]
+        #expect(ImageManager.soleManifestDescriptor(from: manifests) == nil)
+    }
+
+    @Test("empty index returns nil")
+    func emptyIndexReturnsNil() {
+        #expect(ImageManager.soleManifestDescriptor(from: []) == nil)
+    }
+}

--- a/Tests/MockerKitTests/ImageManagerInspectTests.swift
+++ b/Tests/MockerKitTests/ImageManagerInspectTests.swift
@@ -1,5 +1,6 @@
 import Testing
 import Foundation
+import Containerization
 import ContainerizationOCI
 @testable import MockerKit
 
@@ -13,6 +14,26 @@ struct ImageManagerInspectTests {
             size: 100,
             platform: ContainerizationOCI.Platform(arch: arch, os: "linux")
         )
+    }
+
+    private func image(
+        reference: String,
+        digest: String,
+        contentStore: ContainerizationOCI.ContentStore
+    ) -> Containerization.Image {
+        let descriptor = ContainerizationOCI.Descriptor(
+            mediaType: "application/vnd.oci.image.index.v1+json",
+            digest: digest,
+            size: 100
+        )
+        let description = Containerization.Image.Description(reference: reference, descriptor: descriptor)
+        return Containerization.Image(description: description, contentStore: contentStore)
+    }
+
+    private func contentStore() throws -> ContainerizationOCI.ContentStore {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mocker-image-inspect-\(UUID().uuidString)")
+        return try ContainerizationOCI.LocalContentStore(path: directory)
     }
 
     @Test("single-manifest index returns its sole descriptor")
@@ -30,5 +51,67 @@ struct ImageManagerInspectTests {
     @Test("empty index returns nil")
     func emptyIndexReturnsNil() {
         #expect(ImageManager.soleManifestDescriptor(from: []) == nil)
+    }
+
+    @Test("repo metadata is derived from local references with the same descriptor")
+    func repoMetadataUsesLocalAliases() throws {
+        let store = try contentStore()
+        let digest = "sha256:1111111111111111111111111111111111111111111111111111111111111111"
+        let otherDigest = "sha256:2222222222222222222222222222222222222222222222222222222222222222"
+        let inspected = image(reference: "docker.io/library/nginx:latest", digest: digest, contentStore: store)
+        let localImages = [
+            inspected,
+            image(reference: "docker.io/library/nginx:1.25", digest: digest, contentStore: store),
+            image(reference: "registry.example.com/prod/nginx:stable", digest: digest, contentStore: store),
+            image(reference: "registry.example.com/other/nginx:latest", digest: otherDigest, contentStore: store),
+        ]
+
+        let metadata = ImageManager.repoMetadata(
+            for: inspected,
+            localImages: localImages,
+            fallbackReference: "docker.io/library/not-used:latest"
+        )
+
+        #expect(metadata.tags == [
+            "docker.io/library/nginx:1.25",
+            "docker.io/library/nginx:latest",
+            "registry.example.com/prod/nginx:stable",
+        ])
+        #expect(metadata.digests == [
+            "docker.io/library/nginx@\(digest)",
+            "registry.example.com/prod/nginx@\(digest)",
+        ])
+    }
+
+    @Test("digest-only local reference leaves RepoTags empty")
+    func repoMetadataDigestOnlyReference() throws {
+        let store = try contentStore()
+        let digest = "sha256:3333333333333333333333333333333333333333333333333333333333333333"
+        let inspected = image(reference: "docker.io/library/nginx@\(digest)", digest: digest, contentStore: store)
+
+        let metadata = ImageManager.repoMetadata(
+            for: inspected,
+            localImages: [inspected],
+            fallbackReference: "docker.io/library/not-used:latest"
+        )
+
+        #expect(metadata.tags == [])
+        #expect(metadata.digests == ["docker.io/library/nginx@\(digest)"])
+    }
+
+    @Test("tag plus digest local reference strips digest from RepoTags")
+    func repoMetadataTagAndDigestReference() throws {
+        let store = try contentStore()
+        let digest = "sha256:4444444444444444444444444444444444444444444444444444444444444444"
+        let inspected = image(reference: "docker.io/library/nginx:latest@\(digest)", digest: digest, contentStore: store)
+
+        let metadata = ImageManager.repoMetadata(
+            for: inspected,
+            localImages: [inspected],
+            fallbackReference: "docker.io/library/not-used:latest"
+        )
+
+        #expect(metadata.tags == ["docker.io/library/nginx:latest"])
+        #expect(metadata.digests == ["docker.io/library/nginx@\(digest)"])
     }
 }

--- a/Tests/MockerTests/ImageInspectCLITests.swift
+++ b/Tests/MockerTests/ImageInspectCLITests.swift
@@ -1,0 +1,52 @@
+import Testing
+import ArgumentParser
+@testable import Mocker
+
+@Suite("ImageInspect CLI Tests")
+struct ImageInspectCLITests {
+
+    // MARK: - Inspect --type routing
+
+    @Test("--type image routes to image inspect")
+    func typeImageIsImage() throws {
+        let command = try Inspect.parse(["--type", "image", "nginx"])
+        #expect(command.type == "image")
+    }
+
+    @Test("--type container routes to container inspect")
+    func typeContainerIsContainer() throws {
+        let command = try Inspect.parse(["--type", "container", "nginx"])
+        #expect(command.type == "container")
+    }
+
+    @Test("omitting --type leaves type nil (container-first fallback)")
+    func typeNilWhenOmitted() throws {
+        let command = try Inspect.parse(["nginx"])
+        #expect(command.type == nil)
+    }
+
+    // MARK: - Inspect.resolveKind routing decision
+
+    @Test("resolveKind maps type=image to .image")
+    func resolveKindImage() {
+        #expect(Inspect.resolveKind(type: "image") == .image)
+    }
+
+    @Test("resolveKind maps type=container to .container")
+    func resolveKindContainer() {
+        #expect(Inspect.resolveKind(type: "container") == .container)
+    }
+
+    @Test("resolveKind maps nil type to .auto (container-first)")
+    func resolveKindAuto() {
+        #expect(Inspect.resolveKind(type: nil) == .auto)
+    }
+
+    // MARK: - ImageInspect --platform
+
+    @Test("--platform is forwarded to ImageInspect command")
+    func platformOptionParsed() throws {
+        let command = try ImageInspect.parse(["--platform", "linux/amd64", "nginx"])
+        #expect(command.platform == "linux/amd64")
+    }
+}

--- a/Tests/MockerTests/ImageInspectCLITests.swift
+++ b/Tests/MockerTests/ImageInspectCLITests.swift
@@ -1,5 +1,8 @@
 import Testing
 import ArgumentParser
+import Darwin
+import Foundation
+import MockerKit
 @testable import Mocker
 
 @Suite("ImageInspect CLI Tests")
@@ -10,13 +13,13 @@ struct ImageInspectCLITests {
     @Test("--type image routes to image inspect")
     func typeImageIsImage() throws {
         let command = try Inspect.parse(["--type", "image", "nginx"])
-        #expect(command.type == "image")
+        #expect(command.type == .image)
     }
 
     @Test("--type container routes to container inspect")
     func typeContainerIsContainer() throws {
         let command = try Inspect.parse(["--type", "container", "nginx"])
-        #expect(command.type == "container")
+        #expect(command.type == .container)
     }
 
     @Test("omitting --type leaves type nil (container-first fallback)")
@@ -29,12 +32,19 @@ struct ImageInspectCLITests {
 
     @Test("resolveKind maps type=image to .image")
     func resolveKindImage() {
-        #expect(Inspect.resolveKind(type: "image") == .image)
+        #expect(Inspect.resolveKind(type: .image) == .image)
     }
 
     @Test("resolveKind maps type=container to .container")
     func resolveKindContainer() {
-        #expect(Inspect.resolveKind(type: "container") == .container)
+        #expect(Inspect.resolveKind(type: .container) == .container)
+    }
+
+    @Test("--type rejects unsupported values")
+    func typeRejectsUnsupportedValues() {
+        #expect(throws: Error.self) {
+            _ = try Inspect.parse(["--type", "volume", "nginx"])
+        }
     }
 
     @Test("resolveKind maps nil type to .auto (container-first)")
@@ -48,5 +58,60 @@ struct ImageInspectCLITests {
     func platformOptionParsed() throws {
         let command = try ImageInspect.parse(["--platform", "linux/amd64", "nginx"])
         #expect(command.platform == "linux/amd64")
+    }
+
+    @Test("top-level inspect parses --platform without --type")
+    func inspectPlatformOptionParsedInAutoMode() throws {
+        let command = try Inspect.parse(["--platform", "linux/amd64", "nginx"])
+        #expect(command.type == nil)
+        #expect(command.platform == "linux/amd64")
+    }
+
+    @Test("image inspect formatter emits Docker-style JSON array")
+    func imageInspectFormatterEmitsJSONArray() throws {
+        let inspect = MockerKit.ImageInspect(
+            id: "sha256:config",
+            repoTags: ["docker.io/library/nginx:latest"],
+            repoDigests: ["docker.io/library/nginx@sha256:index"],
+            created: "2024-11-19T17:01:02Z",
+            architecture: "arm64",
+            os: "linux",
+            size: 42,
+            config: ImageInspectConfig(env: ["PATH=/usr/bin"]),
+            rootFS: ImageInspectRootFS(type: "layers", layers: ["sha256:layer"])
+        )
+
+        let output = try captureStdout {
+            try TableFormatter.printJSONArray([inspect], escapeSlashes: false)
+        }
+
+        #expect(output.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("["))
+        #expect(output.contains("\"RepoTags\""))
+        #expect(output.contains("docker.io/library/nginx:latest"))
+        #expect(!output.contains("docker.io\\/library\\/nginx"))
+    }
+}
+
+private func captureStdout(_ body: () throws -> Void) throws -> String {
+    let pipe = Pipe()
+    let original = dup(STDOUT_FILENO)
+    precondition(original >= 0)
+    fflush(stdout)
+    dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO)
+
+    do {
+        try body()
+        fflush(stdout)
+        dup2(original, STDOUT_FILENO)
+        close(original)
+        pipe.fileHandleForWriting.closeFile()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        return String(decoding: data, as: UTF8.self)
+    } catch {
+        fflush(stdout)
+        dup2(original, STDOUT_FILENO)
+        close(original)
+        pipe.fileHandleForWriting.closeFile()
+        throw error
     }
 }

--- a/Tests/MockerTests/RelativeDateTests.swift
+++ b/Tests/MockerTests/RelativeDateTests.swift
@@ -1,0 +1,42 @@
+import Testing
+import Foundation
+@testable import Mocker
+
+@Suite("RelativeDate Tests")
+struct RelativeDateTests {
+
+    let nanoTimestamp = "2024-11-19T17:01:02.000000000Z"
+
+    @Test("parse handles 9-digit nanosecond fractional seconds")
+    func parsesNanosecondTimestamp() throws {
+        let date = try #require(RelativeDate.parse(nanoTimestamp))
+        let plain = ISO8601DateFormatter()
+        plain.formatOptions = [.withInternetDateTime]
+        let expected = try #require(plain.date(from: "2024-11-19T17:01:02Z"))
+        #expect(date == expected)
+    }
+
+    @Test("parse handles millisecond fractional seconds")
+    func parsesMillisecondTimestamp() throws {
+        let date = RelativeDate.parse("2024-11-19T17:01:02.123Z")
+        #expect(date != nil)
+    }
+
+    @Test("parse handles plain RFC3339 without fractional seconds")
+    func parsesPlainTimestamp() throws {
+        let date = RelativeDate.parse("2024-11-19T17:01:02Z")
+        #expect(date != nil)
+    }
+
+    @Test("humanRelative does not return the raw nanosecond string")
+    func humanRelativeNotRawForNanoseconds() {
+        let result = RelativeDate.humanRelative(nanoTimestamp)
+        #expect(result != nanoTimestamp)
+    }
+
+    @Test("humanRelative falls back to raw string for unparseable input")
+    func humanRelativeFallsBackForGarbage() {
+        let garbage = "not-a-timestamp"
+        #expect(RelativeDate.humanRelative(garbage) == garbage)
+    }
+}

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -183,16 +183,27 @@ mocker logs --tail 100 myapp
 Return low-level information on containers or images.
 
 ```bash
-mocker inspect TARGET [TARGET...]
+mocker inspect [OPTIONS] TARGET [TARGET...]
 ```
 
 Always returns a JSON array, even for a single target.
+
+**Flags:**
+```
+--type       Only inspect objects of this type (image|container)
+--platform   Inspect a specific image platform (for example linux/amd64)
+```
+
+Image inspection uses Docker-compatible `ImageInspect` JSON arrays with
+PascalCase fields. `mocker inspect --type image IMAGE` and
+`mocker image inspect IMAGE` return the same image output.
 
 **Examples:**
 ```bash
 mocker inspect myapp
 mocker inspect alpine:latest
 mocker inspect myapp | jq '.[0].state'
+mocker inspect --type image --platform linux/amd64 alpine:latest
 ```
 
 ---
@@ -272,6 +283,29 @@ mocker images [OPTIONS]
 mocker images
 mocker images -q
 mocker rmi $(mocker images -q)
+```
+
+---
+
+### `mocker image inspect`
+
+Display Docker-compatible details for one or more images.
+
+```bash
+mocker image inspect [OPTIONS] IMAGE [IMAGE...]
+```
+
+Always returns a JSON array using Docker `ImageInspect` field names.
+
+**Flags:**
+```
+--platform   Inspect a specific platform of a multi-platform image
+```
+
+**Examples:**
+```bash
+mocker image inspect alpine:latest
+mocker image inspect --platform linux/amd64 alpine:latest
 ```
 
 ---

--- a/docs/zh-CN/cli-reference.md
+++ b/docs/zh-CN/cli-reference.md
@@ -18,6 +18,7 @@ Mocker 所有命令和参数的完整参考文档。
   - [pull](#pull)
   - [push](#push)
   - [images](#images)
+  - [image inspect](#image-inspect)
   - [build](#build)
   - [tag](#tag)
   - [rmi](#rmi)
@@ -266,10 +267,21 @@ mocker logs --tail 100 myapp
 返回容器或镜像的底层详细信息。
 
 ```
-mocker inspect 目标 [目标...]
+mocker inspect [选项] 目标 [目标...]
 ```
 
 返回 JSON 数组，自动识别目标是容器还是镜像。
+
+**选项：**
+
+| 参数 | 说明 |
+|------|------|
+| `--type` | 只检查指定类型：`image` 或 `container` |
+| `--platform` | 检查指定镜像平台，例如 `linux/amd64` |
+
+镜像检查输出为 Docker 兼容的 `ImageInspect` JSON 数组，字段使用
+PascalCase。`mocker inspect --type image 镜像` 和
+`mocker image inspect 镜像` 返回相同的镜像输出。
 
 **示例：**
 
@@ -285,6 +297,9 @@ mocker inspect myapp postgres:15
 
 # 配合 jq 使用
 mocker inspect myapp | jq '.[0].state'
+
+# 检查指定平台的镜像
+mocker inspect --type image --platform linux/amd64 alpine:latest
 ```
 
 **输出格式：**
@@ -410,6 +425,31 @@ mocker images -q
 
 # 删除所有镜像（谨慎使用）
 mocker rmi $(mocker images -q)
+```
+
+---
+
+### image inspect
+
+显示一个或多个镜像的 Docker 兼容详细信息。
+
+```
+mocker image inspect [选项] 镜像 [镜像...]
+```
+
+始终返回使用 Docker `ImageInspect` 字段名的 JSON 数组。
+
+**选项：**
+
+| 参数 | 说明 |
+|------|------|
+| `--platform` | 检查多平台镜像的指定平台 |
+
+**示例：**
+
+```bash
+mocker image inspect alpine:latest
+mocker image inspect --platform linux/amd64 alpine:latest
 ```
 
 ---


### PR DESCRIPTION
`mocker image inspect` and `mocker inspect --type=image` produced different,
non-Docker-compatible output, and `inspect --type` was parsed but never applied. Both
commands now emit one identical, Docker-compatible `ImageInspect` JSON array (matching
the Docker Engine contract, `moby/moby@docker-v29.5.3`), and `--type` routing is fixed.

Closes #24 

## What changed

- New `ImageInspect` DTO in `MockerKit` + a pure
  `mapToImageInspect(config:manifest:reference:indexDigest:)`.
- `ImageManager.inspect()` reads the OCI manifest + config and populates real data:
  `Size` (sum of layer sizes), `Id` (config digest), `Created`, `Architecture`, `Os`,
  `Variant`, `OsVersion`, `Config`, `RootFS`. Previously `Size`/`Created` were stubbed.
- Both inspect commands share one serializer → identical output.
- `inspect --type` is honored, with a host-platform default and `--platform` override.
- Fixes a `mocker history` regression parsing nanosecond RFC3339 timestamps.

## Note on scope

Two of these were not in the original report and surfaced while implementing the fix:

- `inspect --type`: included because `inspect --type=image` cannot match `image inspect`
  unless the flag is actually applied, so it is needed for the two commands to be equivalent.
- `mocker history`: a small, incidental side effect. `history` calls the same `inspect()`,
  and once it returns real nanosecond timestamps the existing date parser regressed, so it
  is fixed here. It is not part of the original issue, and I am happy to pull it into a
  separate PR if you would rather keep this one tightly scoped.

Hope these are welcome.

## Testing

`swift test` → 124/124 passing, including golden-fixture conformance tests for the mapping.

## Breaking changes

- `image inspect` / `inspect --type=image` output is now the Docker `ImageInspect` shape:
  a JSON array of objects with PascalCase keys (`Id`, `RepoTags`, `Created`, `Size`,
  `Config`, `RootFS`, ...) instead of a single object with lowercase keys (`id`,
  `repository`, `tag`, `size`, `created`, `labels`).
- `Id` now reports the image config digest (Docker parity).
- `MockerKit`: `ImageManager.inspect(_:)` now returns `ImageInspect` (was `ImageInfo`)
  and takes an optional `platform:`.

## Review note

Two commits: the `MockerKit` model + tests, then the CLI wiring + `--type` fix.
