### PR TITLE
fix(build,compose): resolve dockerfile path per Docker semantics

### DIFF
--- a/Sources/Mocker/Commands/Build.swift
+++ b/Sources/Mocker/Commands/Build.swift
@@ -13,7 +13,7 @@ struct Build: AsyncParsableCommand {
     var tag: String
 
     @Option(name: .shortAndLong, help: "Name of the Dockerfile")
-    var file: String = "Dockerfile"
+    var file: String?
 
     @Flag(name: .long, help: "Do not use cache when building")
     var noCache = false

--- a/Sources/Mocker/Commands/Compose.swift
+++ b/Sources/Mocker/Commands/Compose.swift
@@ -580,10 +580,14 @@ struct ComposeBuildCommand: AsyncParsableCommand {
             guard let buildConfig = service.build else { continue }
             let tag = service.image ?? "\(name):latest"
             if !quiet { print("Building \(name)...") }
-            // Compose-file `build.args` first, then CLI `--build-arg` so CLI wins on conflict.
+            let dockerfilePath = ImageManager.composeDockerfilePath(
+                context: buildConfig.context,
+                dockerfile: buildConfig.dockerfile ?? "Dockerfile",
+                cwd: FileManager.default.currentDirectoryPath
+            )
             _ = try await manager.build(
                 tag: tag, context: buildConfig.context,
-                dockerfile: buildConfig.dockerfile ?? "Dockerfile",
+                dockerfile: dockerfilePath,
                 noCache: noCache, buildArgs: buildConfig.argList + buildArg,
                 target: buildConfig.target
             )

--- a/Sources/MockerKit/Compose/ComposeOrchestrator.swift
+++ b/Sources/MockerKit/Compose/ComposeOrchestrator.swift
@@ -222,10 +222,15 @@ public actor ComposeOrchestrator {
                 shouldBuild = !existingImages.contains { ComposeService.imageMatches($0, tag: tag) }
             }
             if shouldBuild {
+                let dockerfilePath = ImageManager.composeDockerfilePath(
+                    context: build.context,
+                    dockerfile: build.dockerfile ?? "Dockerfile",
+                    cwd: FileManager.default.currentDirectoryPath
+                )
                 _ = try await imageManager.build(
                     tag: tag,
                     context: build.context,
-                    dockerfile: build.dockerfile ?? "Dockerfile",
+                    dockerfile: dockerfilePath,
                     buildArgs: build.argList,
                     target: build.target
                 )

--- a/Sources/MockerKit/Image/ImageManager.swift
+++ b/Sources/MockerKit/Image/ImageManager.swift
@@ -241,6 +241,11 @@ public actor ImageManager {
         return args
     }
 
+    static func resolveContextPath(context: String, cwd: String) -> String {
+        guard !context.hasPrefix("/") else { return context }
+        return URL(fileURLWithPath: cwd).appendingPathComponent(context).standardized.path
+    }
+
     static func resolveDockerfilePath(context: String, dockerfile: String?, cwd: String) -> String {
         guard let dockerfile else {
             return URL(fileURLWithPath: context).appendingPathComponent("Dockerfile").standardized.path
@@ -251,21 +256,21 @@ public actor ImageManager {
         return URL(fileURLWithPath: cwd).appendingPathComponent(dockerfile).standardized.path
     }
 
+    /// Resolve a Compose service's `build.dockerfile` to an absolute path using Docker Compose semantics:
+    /// relative `dockerfile` is relative to `build.context`, not the CWD.
+    public static func composeDockerfilePath(context: String, dockerfile: String, cwd: String) -> String {
+        let absContext = resolveContextPath(context: context, cwd: cwd)
+        return resolveDockerfilePath(context: absContext, dockerfile: dockerfile, cwd: absContext)
+    }
+
     /// Build an image from a Dockerfile using the `container` CLI.
     /// - Parameter platforms: pass multiple values to build a multi-arch manifest list (e.g. `["linux/amd64", "linux/arm64"]`).
     /// - Parameter builder: optional named builder instance forwarded to `container build --builder`,
     ///   enabling a remote BuildKit node for exotic architectures (apple/container#1496).
     public func build(tag: String, context: String, dockerfile: String? = nil, noCache: Bool = false, buildArgs: [String] = [], platforms: [String] = [], target: String? = nil, labels: [String] = [], quiet: Bool = false, progress: String? = nil, output: [String] = [], builder: String? = nil) async throws -> ImageInfo {
-        let contextURL: URL
-        if context.hasPrefix("/") {
-            contextURL = URL(fileURLWithPath: context)
-        } else {
-            contextURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-                .appendingPathComponent(context)
-                .standardized
-        }
+        let absContext = Self.resolveContextPath(context: context, cwd: FileManager.default.currentDirectoryPath)
         let dockerfilePath = Self.resolveDockerfilePath(
-            context: contextURL.path,
+            context: absContext,
             dockerfile: dockerfile,
             cwd: FileManager.default.currentDirectoryPath
         )

--- a/Sources/MockerKit/Image/ImageManager.swift
+++ b/Sources/MockerKit/Image/ImageManager.swift
@@ -241,11 +241,21 @@ public actor ImageManager {
         return args
     }
 
+    static func resolveDockerfilePath(context: String, dockerfile: String?, cwd: String) -> String {
+        guard let dockerfile else {
+            return URL(fileURLWithPath: context).appendingPathComponent("Dockerfile").standardized.path
+        }
+        if dockerfile.hasPrefix("/") {
+            return dockerfile
+        }
+        return URL(fileURLWithPath: cwd).appendingPathComponent(dockerfile).standardized.path
+    }
+
     /// Build an image from a Dockerfile using the `container` CLI.
     /// - Parameter platforms: pass multiple values to build a multi-arch manifest list (e.g. `["linux/amd64", "linux/arm64"]`).
     /// - Parameter builder: optional named builder instance forwarded to `container build --builder`,
     ///   enabling a remote BuildKit node for exotic architectures (apple/container#1496).
-    public func build(tag: String, context: String, dockerfile: String = "Dockerfile", noCache: Bool = false, buildArgs: [String] = [], platforms: [String] = [], target: String? = nil, labels: [String] = [], quiet: Bool = false, progress: String? = nil, output: [String] = [], builder: String? = nil) async throws -> ImageInfo {
+    public func build(tag: String, context: String, dockerfile: String? = nil, noCache: Bool = false, buildArgs: [String] = [], platforms: [String] = [], target: String? = nil, labels: [String] = [], quiet: Bool = false, progress: String? = nil, output: [String] = [], builder: String? = nil) async throws -> ImageInfo {
         let contextURL: URL
         if context.hasPrefix("/") {
             contextURL = URL(fileURLWithPath: context)
@@ -254,7 +264,11 @@ public actor ImageManager {
                 .appendingPathComponent(context)
                 .standardized
         }
-        let dockerfilePath = contextURL.appendingPathComponent(dockerfile).path
+        let dockerfilePath = Self.resolveDockerfilePath(
+            context: contextURL.path,
+            dockerfile: dockerfile,
+            cwd: FileManager.default.currentDirectoryPath
+        )
 
         guard FileManager.default.fileExists(atPath: dockerfilePath) else {
             throw MockerError.buildError("Dockerfile not found at \(dockerfilePath)")

--- a/Tests/MockerKitTests/ImageManagerBuildArgsTests.swift
+++ b/Tests/MockerKitTests/ImageManagerBuildArgsTests.swift
@@ -96,3 +96,86 @@ struct ImageManagerBuildArgsTests {
         return false
     }
 }
+
+@Suite("ImageManager Dockerfile path resolver")
+struct ImageManagerDockerfileResolverTests {
+
+    // Scenario 1 (spec): absolute -f is used verbatim — devcontainer regression case
+    @Test("absolute -f path is returned verbatim")
+    func resolveAbsoluteUsedVerbatim() {
+        let result = ImageManager.resolveDockerfilePath(
+            context: "/var/work/build-1234",
+            dockerfile: "/var/work/build-1234/Dockerfile.buildContent",
+            cwd: "/some/unrelated/cwd"
+        )
+        #expect(result == "/var/work/build-1234/Dockerfile.buildContent")
+    }
+
+    // Scenario 1 negative assertion: absolute -f must NOT be doubled onto context
+    @Test("absolute -f is not concatenated onto context")
+    func resolveAbsoluteNotDoubled() {
+        let result = ImageManager.resolveDockerfilePath(
+            context: "/var/work/build-1234",
+            dockerfile: "/var/work/build-1234/Dockerfile.buildContent",
+            cwd: "/some/unrelated/cwd"
+        )
+        #expect(!result.contains("/var/work/build-1234/var/work/build-1234"))
+    }
+
+    // Scenario 3 (spec): relative -f resolved against CWD, not context
+    @Test("relative -f resolves against CWD when CWD differs from context")
+    func resolveRelativeCWDNotContext() {
+        let result = ImageManager.resolveDockerfilePath(
+            context: "/srv/builds/ctx",
+            dockerfile: "dockerfiles/Dockerfile.prod",
+            cwd: "/home/user/project"
+        )
+        #expect(result == "/home/user/project/dockerfiles/Dockerfile.prod")
+    }
+
+    // Scenario 4 (spec): relative -f where CWD equals context — no regression for common case
+    @Test("relative -f where CWD equals context produces same result as before")
+    func resolveRelativeCWDEqualsContext() {
+        let result = ImageManager.resolveDockerfilePath(
+            context: "/home/user/myapp",
+            dockerfile: "Dockerfile.dev",
+            cwd: "/home/user/myapp"
+        )
+        #expect(result == "/home/user/myapp/Dockerfile.dev")
+    }
+
+    // Scenario 5 (spec): nil -f uses context root
+    @Test("nil dockerfile resolves to context/Dockerfile")
+    func resolveNilUsesContextRoot() {
+        let result = ImageManager.resolveDockerfilePath(
+            context: "/srv/builds/ctx",
+            dockerfile: nil,
+            cwd: "/some/cwd"
+        )
+        #expect(result == "/srv/builds/ctx/Dockerfile")
+    }
+
+    // Scenario 6 (spec): missing abs path — resolver returns correct non-doubled string
+    @Test("missing absolute path resolves to the verbatim path string")
+    func resolveMissingAbsolutePathString() {
+        let result = ImageManager.resolveDockerfilePath(
+            context: "/any/context",
+            dockerfile: "/nonexistent/path/Dockerfile",
+            cwd: "/any/cwd"
+        )
+        #expect(result == "/nonexistent/path/Dockerfile")
+        #expect(!result.contains("/any/context/nonexistent"))
+    }
+
+    // Scenario 7 (spec): missing default path — nil + context → context/Dockerfile, not doubled
+    @Test("missing default dockerfile resolves to context/Dockerfile without doubling")
+    func resolveMissingDefaultPathString() {
+        let result = ImageManager.resolveDockerfilePath(
+            context: "/some/context",
+            dockerfile: nil,
+            cwd: "/any/cwd"
+        )
+        #expect(result == "/some/context/Dockerfile")
+        #expect(!result.contains("/some/context/some/context"))
+    }
+}

--- a/Tests/MockerKitTests/ImageManagerBuildArgsTests.swift
+++ b/Tests/MockerKitTests/ImageManagerBuildArgsTests.swift
@@ -97,6 +97,66 @@ struct ImageManagerBuildArgsTests {
     }
 }
 
+@Suite("ImageManager Compose dockerfile path resolver")
+struct ImageManagerComposeDockerfilePathTests {
+
+    // Regression: context=./app, cwd=/project, dockerfile=default → must be /project/app/Dockerfile, NOT /project/Dockerfile
+    @Test("default dockerfile resolves relative to context, not CWD (regression guard)")
+    func composeDefaultDockerfileResolvesRelativeToContext() {
+        let result = ImageManager.composeDockerfilePath(
+            context: "./app",
+            dockerfile: "Dockerfile",
+            cwd: "/project"
+        )
+        #expect(result == "/project/app/Dockerfile")
+        #expect(result != "/project/Dockerfile")
+    }
+
+    // relative dockerfile resolves relative to context, not CWD
+    @Test("relative dockerfile resolves relative to context")
+    func composeRelativeDockerfileResolvesRelativeToContext() {
+        let result = ImageManager.composeDockerfilePath(
+            context: "./app",
+            dockerfile: "Dockerfile.prod",
+            cwd: "/project"
+        )
+        #expect(result == "/project/app/Dockerfile.prod")
+    }
+
+    // absolute dockerfile is returned verbatim regardless of context
+    @Test("absolute dockerfile is returned verbatim")
+    func composeAbsoluteDockerfileVerbatim() {
+        let result = ImageManager.composeDockerfilePath(
+            context: "./app",
+            dockerfile: "/custom/path/Dockerfile",
+            cwd: "/project"
+        )
+        #expect(result == "/custom/path/Dockerfile")
+    }
+
+    // context already absolute — still resolves dockerfile relative to it
+    @Test("absolute context with relative dockerfile resolves correctly")
+    func composeAbsoluteContextRelativeDockerfile() {
+        let result = ImageManager.composeDockerfilePath(
+            context: "/project/app",
+            dockerfile: "Dockerfile.dev",
+            cwd: "/project"
+        )
+        #expect(result == "/project/app/Dockerfile.dev")
+    }
+
+    // context == CWD — common case, must also be correct
+    @Test("when context equals CWD relative dockerfile resolves to context/dockerfile")
+    func composeContextEqualsCWD() {
+        let result = ImageManager.composeDockerfilePath(
+            context: ".",
+            dockerfile: "Dockerfile",
+            cwd: "/project"
+        )
+        #expect(result == "/project/Dockerfile")
+    }
+}
+
 @Suite("ImageManager Dockerfile path resolver")
 struct ImageManagerDockerfileResolverTests {
 

--- a/Tests/MockerTests/CLITests.swift
+++ b/Tests/MockerTests/CLITests.swift
@@ -210,4 +210,16 @@ struct CLITests {
         let byName = try ContainerLs.parse(["--filter", "name=db"]).options
         #expect(byName.filtered(containers).map(\.id) == ["b"])
     }
+
+    @Test("Build -f flag parses to the provided path")
+    func buildFileOptionParsesPath() throws {
+        let command = try Build.parse(["-f", "/abs/path/Dockerfile", "-t", "x:1", "."])
+        #expect(command.file == "/abs/path/Dockerfile")
+    }
+
+    @Test("Build -f flag defaults to nil when omitted")
+    func buildFileOptionDefaultsNil() throws {
+        let command = try Build.parse(["-t", "x:1", "."])
+        #expect(command.file == nil)
+    }
 }


### PR DESCRIPTION
## What problem does this solve?

`mocker build -f <abs path> <abs context>` fails with `Dockerfile not found at <doubled-path>` because `ImageManager.build` calls `URL.appendingPathComponent` on the dockerfile argument, which doesn't treat absolute paths as special — it concatenates them onto the build context. The `fileExists` guard then throws before `container build` is ever invoked.

Per docs.docker.com (`docker buildx build --file`): an absolute `-f` is used verbatim, a relative `-f` is resolved against the current working directory. mocker now matches both.

Naïvely fixing only `mocker build` would have shifted Compose (which reuses `ImageManager.build`) from context-relative dockerfile resolution to CWD-relative — a regression, because the Compose spec resolves `build.dockerfile` relative to the service's `build.context`. Both surfaces are corrected together so the Docker-compat contract holds on both:

- absolute `-f` → used verbatim
- relative `-f` → CWD-relative for `mocker build`, context-relative for Compose
- omitted → `<context>/Dockerfile`

## What changed

- `Sources/MockerKit/Image/ImageManager.swift`: extracted `resolveContextPath(context:cwd:)` from the inline absolute/relative branch in `build` (de-duplicates the same logic that lived inline); added pure `resolveDockerfilePath(context:dockerfile:cwd:)` with `cwd` injected so it is testable without the filesystem; added `public static composeDockerfilePath(context:dockerfile:cwd:)` that chains the two so Compose can pre-resolve the dockerfile against its context — no new path-resolution policy added, just reuse. `build(dockerfile:)` parameter widened from `String = "Dockerfile"` to `String? = nil` so the three branches (nil / absolute / relative) stay distinguishable end-to-end.
- `Sources/Mocker/Commands/Build.swift`: `@Option var file` is now `String?` so ArgumentParser surfaces "not provided" as `nil` instead of the literal `"Dockerfile"`.
- `Sources/MockerKit/Compose/ComposeOrchestrator.swift`, `Sources/Mocker/Commands/Compose.swift`: pre-resolve the dockerfile via `composeDockerfilePath` before calling `imageManager.build`, so a relative `build.dockerfile` stays context-relative.

## How was it tested?

`swift test`: 151/151, 0 failures (14 new tests). 12 pure resolver tests in `Tests/MockerKitTests/ImageManagerBuildArgsTests.swift` cover all three branches, the CWD-vs-context divergence, the original doubled-path case, and Compose context-relative resolution; 2 parse tests in `Tests/MockerTests/CLITests.swift` assert `-f` omitted parses to `nil`.

## Any breaking changes?

No. Widening `dockerfile: String = "Dockerfile"` to `dockerfile: String? = nil` on `ImageManager.build` is source-compatible: callers that omit `dockerfile:` keep using the default, and callers passing a `String` literal widen implicitly to `String?`. No existing call-site outside the two Compose sites updated above required modification.
