### PR TITLE
fix!: pass container command/args literally in run/create/exec/compose

### DIFF
--- a/Sources/Mocker/Commands/Compose.swift
+++ b/Sources/Mocker/Commands/Compose.swift
@@ -733,7 +733,8 @@ struct ComposePush: AsyncParsableCommand {
 struct ComposeExec: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "exec",
-        abstract: "Execute a command in a running service container"
+        abstract: "Execute a command in a running service container",
+        discussion: "Usage: mocker compose exec [OPTIONS] SERVICE COMMAND [ARG...]"
     )
 
     @OptionGroup var options: ComposeOptions
@@ -741,7 +742,7 @@ struct ComposeExec: AsyncParsableCommand {
     @Argument(help: "Service name")
     var service: String
 
-    @Argument(help: "Command to execute")
+    @Argument(parsing: .captureForPassthrough, help: "Command to execute")
     var command: [String]
 
     @Flag(name: .shortAndLong, help: "Detached mode")
@@ -774,6 +775,12 @@ struct ComposeExec: AsyncParsableCommand {
     @Flag(name: .long, help: "Give extended privileges to the process")
     var privileged = false
 
+    mutating func validate() throws {
+        if command.first == "--" {
+            command.removeFirst()
+        }
+    }
+
     func run() async throws {
         let (_, project) = try options.loadCompose()
         let config = MockerConfig()
@@ -789,7 +796,8 @@ struct ComposeExec: AsyncParsableCommand {
 struct ComposeRun: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "run",
-        abstract: "Run a one-off command on a service"
+        abstract: "Run a one-off command on a service",
+        discussion: "Usage: mocker compose run [OPTIONS] SERVICE [COMMAND] [ARG...]"
     )
 
     @OptionGroup var options: ComposeOptions
@@ -797,7 +805,7 @@ struct ComposeRun: AsyncParsableCommand {
     @Argument(help: "Service name")
     var service: String
 
-    @Argument(help: "Command to execute")
+    @Argument(parsing: .captureForPassthrough, help: "Command to execute")
     var command: [String] = []
 
     @Flag(name: .shortAndLong, help: "Run container in background")
@@ -880,6 +888,12 @@ struct ComposeRun: AsyncParsableCommand {
 
     @Flag(name: [.customShort("P"), .customLong("publish-all")], help: "Publish all exposed ports to random host ports")
     var publishAll = false
+
+    mutating func validate() throws {
+        if command.first == "--" {
+            command.removeFirst()
+        }
+    }
 
     func run() async throws {
         let (composeFile, _) = try options.loadCompose()

--- a/Sources/Mocker/Commands/Create.swift
+++ b/Sources/Mocker/Commands/Create.swift
@@ -4,13 +4,14 @@ import Foundation
 
 struct Create: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
-        abstract: "Create a new container"
+        abstract: "Create a new container",
+        discussion: "Usage: mocker create [OPTIONS] IMAGE [COMMAND] [ARG...]"
     )
 
     @Argument(help: "Image to use")
     var image: String
 
-    @Argument(help: "Command to execute in the container")
+    @Argument(parsing: .captureForPassthrough, help: "Command to execute in the container")
     var command: [String] = []
 
     @Option(name: .long, help: "Assign a name to the container")
@@ -302,6 +303,12 @@ struct Create: AsyncParsableCommand {
 
     @Option(name: .customLong("volumes-from"), parsing: .singleValue, help: "Mount volumes from the specified container(s)")
     var volumesFrom: [String] = []
+
+    mutating func validate() throws {
+        if command.first == "--" {
+            command.removeFirst()
+        }
+    }
 
     func run() async throws {
         let config = MockerConfig()

--- a/Sources/Mocker/Commands/Exec.swift
+++ b/Sources/Mocker/Commands/Exec.swift
@@ -3,13 +3,14 @@ import MockerKit
 
 struct Exec: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
-        abstract: "Execute a command in a running container"
+        abstract: "Execute a command in a running container",
+        discussion: "Usage: mocker exec [OPTIONS] CONTAINER COMMAND [ARG...]"
     )
 
     @Argument(help: "Container name or ID")
     var container: String
 
-    @Argument(help: "Command to execute")
+    @Argument(parsing: .captureForPassthrough, help: "Command to execute")
     var command: [String]
 
     @Flag(name: .shortAndLong, help: "Keep STDIN open even if not attached")
@@ -38,6 +39,12 @@ struct Exec: AsyncParsableCommand {
 
     @Flag(name: .long, help: "Give extended privileges to the command")
     var privileged = false
+
+    mutating func validate() throws {
+        if command.first == "--" {
+            command.removeFirst()
+        }
+    }
 
     func run() async throws {
         let config = MockerConfig()

--- a/Sources/Mocker/Commands/Run.swift
+++ b/Sources/Mocker/Commands/Run.swift
@@ -4,13 +4,14 @@ import Foundation
 
 struct Run: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
-        abstract: "Create and run a new container"
+        abstract: "Create and run a new container",
+        discussion: "Usage: mocker run [OPTIONS] IMAGE [COMMAND] [ARG...]"
     )
 
     @Argument(help: "Image to run")
     var image: String
 
-    @Argument(help: "Command to execute in the container")
+    @Argument(parsing: .captureForPassthrough, help: "Command to execute in the container")
     var command: [String] = []
 
     @Option(name: .long, help: "Assign a name to the container")
@@ -311,6 +312,12 @@ struct Run: AsyncParsableCommand {
 
     @Option(name: .customLong("volumes-from"), parsing: .singleValue, help: "Mount volumes from the specified container(s)")
     var volumesFrom: [String] = []
+
+    mutating func validate() throws {
+        if command.first == "--" {
+            command.removeFirst()
+        }
+    }
 
     func run() async throws {
         // Fail-fast for flags not supported by Apple Containerization runtime

--- a/Tests/MockerTests/CLITests.swift
+++ b/Tests/MockerTests/CLITests.swift
@@ -222,4 +222,78 @@ struct CLITests {
         let command = try Build.parse(["-t", "x:1", "."])
         #expect(command.file == nil)
     }
+
+    @Test("Run passes args after image to container")
+    func runPassthroughAfterImage() throws {
+        let command = try Run.parse(["--rm", "img", "ls", "-la", "/stuff/"])
+        #expect(command.command == ["ls", "-la", "/stuff/"])
+        #expect(command.rm == true)
+    }
+
+    @Test("Create passes args after image to container")
+    func createPassthroughAfterImage() throws {
+        let command = try Create.parse(["img", "cmd", "-flag"])
+        #expect(command.command == ["cmd", "-flag"])
+    }
+
+    @Test("Exec passes args after container to command")
+    func execPassthroughAfterContainer() throws {
+        let command = try Exec.parse(["ctn", "ls", "-la"])
+        #expect(command.command == ["ls", "-la"])
+    }
+
+    @Test("Compose run passes args after service to container")
+    func composeRunPassthroughAfterService() throws {
+        let command = try ComposeRun.parse(["svc", "ls", "-la"])
+        #expect(command.command == ["ls", "-la"])
+    }
+
+    @Test("Compose exec passes args after service to command")
+    func composeExecPassthroughAfterService() throws {
+        let command = try ComposeExec.parse(["svc", "ls", "-la"])
+        #expect(command.command == ["ls", "-la"])
+    }
+
+    @Test("Run strips leading -- terminator")
+    func runStripsLeadingDoubleDash() throws {
+        var command = try Run.parse(["--rm", "img", "--", "ls", "-la"])
+        try command.validate()
+        #expect(command.command == ["ls", "-la"])
+        #expect(command.rm == true)
+    }
+
+    @Test("Run preserves non-leading -- inside command")
+    func runPreservesNonLeadingDoubleDash() throws {
+        var command = try Run.parse(["img", "ls", "--", "-la"])
+        try command.validate()
+        #expect(command.command == ["ls", "--", "-la"])
+    }
+
+    @Test("Create strips leading -- terminator")
+    func createStripsLeadingDoubleDash() throws {
+        var command = try Create.parse(["img", "--", "cmd", "-flag"])
+        try command.validate()
+        #expect(command.command == ["cmd", "-flag"])
+    }
+
+    @Test("Exec strips leading -- terminator")
+    func execStripsLeadingDoubleDash() throws {
+        var command = try Exec.parse(["ctn", "--", "ls", "-la"])
+        try command.validate()
+        #expect(command.command == ["ls", "-la"])
+    }
+
+    @Test("Compose run strips leading -- terminator")
+    func composeRunStripsLeadingDoubleDash() throws {
+        var command = try ComposeRun.parse(["svc", "--", "ls", "-la"])
+        try command.validate()
+        #expect(command.command == ["ls", "-la"])
+    }
+
+    @Test("Compose exec strips leading -- terminator")
+    func composeExecStripsLeadingDoubleDash() throws {
+        var command = try ComposeExec.parse(["svc", "--", "ls", "-la"])
+        try command.validate()
+        #expect(command.command == ["ls", "-la"])
+    }
 }


### PR DESCRIPTION
## What problem does this solve?

`mocker run img ls -la /stuff/` fails with a parse error because ArgumentParser's default array strategy keeps scanning for flags after the first positional, so `-la` collides with `-a/--attach` on `Run`. The same trap exists on `create`, `exec`, `compose run`, and `compose exec`.

Docker's CLI uses pflag with `SetInterspersed(false)`: once the positional (`IMAGE`/`CONTAINER`/`SERVICE`) is consumed, every following token is forwarded to the container verbatim. The only workaround on mocker today is the `--` terminator, which is invisible to new users and unnecessary friction on the flagship use case.

## What changed

- Add `parsing: .captureForPassthrough` to the five `@Argument var command: [String]` sites (`Run`, `Create`, `Exec`, `ComposeExec`, `ComposeRun`). Once parsing reaches the positional, every subsequent token — including flag-looking ones — is captured literally. This is the Swift-native equivalent of pflag's `SetInterspersed(false)`.

- `.captureForPassthrough` includes the `--` terminator in the captured array, which would make the engine try to `exec("--", ...)`. Add `mutating func validate()` to each of the five commands to drop a single leading `--`. Non-leading `--` inside the command stays literal, so `mocker run img ls -- -la` keeps working as expected.

- Add `discussion:` on each subcommand's `CommandConfiguration` with the canonical Docker-shaped usage form, so `--help` shows the pre-positional flag placement and matches Docker's required/optional brackets exactly (`exec` and `compose exec` show `COMMAND` without brackets because it is required there).

## Breaking change

Subcommand flags placed AFTER the positional are now captured as container command arguments instead of being parsed by the subcommand. `mocker exec ctn -it bash` must become `mocker exec -it ctn bash`. Marked with `fix!` and a `BREAKING CHANGE:` footer; release-please bumps minor under the pre-1.0 policy.
