### PR TITLE
feat(compose): parse resource limits (mem_limit, cpus, deploy.resources) and forward to container runtime

### DIFF
--- a/Sources/MockerKit/Compose/ComposeFile.swift
+++ b/Sources/MockerKit/Compose/ComposeFile.swift
@@ -259,13 +259,13 @@ public struct ComposeService: Sendable {
         }
 
         // Parse resource limits: deploy.resources overrides legacy top-level fields
-        let memLimit = parseDeployNested(dict["deploy"], "resources", "limits", "memory") ?? parseStringValue(dict["mem_limit"])
-        let cpus = parseDeployNested(dict["deploy"], "resources", "limits", "cpus") ?? parseCpusValue(dict["cpus"])
-        let memReservation = parseDeployNested(dict["deploy"], "resources", "reservations", "memory") ?? parseStringValue(dict["mem_reservation"])
-        let cpusReservation = parseDeployNested(dict["deploy"], "resources", "reservations", "cpus")
+        let memLimit = parseStringValue(deployLeaf(dict["deploy"], "resources", "limits", "memory")) ?? parseStringValue(dict["mem_limit"])
+        let cpus = parseStringValue(deployLeaf(dict["deploy"], "resources", "limits", "cpus")) ?? parseStringValue(dict["cpus"])
+        let memReservation = parseStringValue(deployLeaf(dict["deploy"], "resources", "reservations", "memory")) ?? parseStringValue(dict["mem_reservation"])
+        let cpusReservation = parseStringValue(deployLeaf(dict["deploy"], "resources", "reservations", "cpus"))
         let memSwapLimit = parseStringValue(dict["memswap_limit"])
         let shmSize = parseStringValue(dict["shm_size"])
-        let pidsLimit = parseIntValue(dict["pids_limit"]) ?? parseDeployInt(dict["deploy"], "resources", "limits", "pids")
+        let pidsLimit = parseIntValue(deployLeaf(dict["deploy"], "resources", "limits", "pids")) ?? parseIntValue(dict["pids_limit"])
 
         // Parse deploy.restart_policy — overrides legacy `restart` field per Compose spec
         let restartPolicy = parseRestartPolicy(dict["deploy"])
@@ -274,7 +274,8 @@ public struct ComposeService: Sendable {
         let restartPolicyMaxAttempts: Int?
         let restartPolicyWindow: String?
         if let rp = restartPolicy {
-            restartValue = rp.condition.map { mapRestartCondition($0) }
+            // A restart_policy without a `condition` still honors the legacy `restart` field.
+            restartValue = rp.condition.map { mapRestartCondition($0) } ?? (dict["restart"] as? String)
             restartPolicyDelay = rp.delay
             restartPolicyMaxAttempts = rp.maxAttempts
             restartPolicyWindow = rp.window
@@ -450,35 +451,16 @@ public struct ComposeService: Sendable {
         return nil
     }
 
-    /// Parse `cpus` — fractional number (`0.5`) or string (`"0.50"`).
-    private static func parseCpusValue(_ value: Any?) -> String? {
-        guard let value else { return nil }
-        if let str = value as? String { return str }
-        if let num = value as? Double { return String(num) }
-        if let num = value as? Int { return String(num) }
-        return nil
-    }
-
-    /// Walk a nested deploy path like `deploy.resources.limits.memory`.
-    private static func parseDeployNested(_ value: Any?, _ path: String...) -> String? {
+    /// Walk a nested deploy path like `deploy.resources.limits.memory` and return the raw leaf node.
+    /// Callers apply `parseStringValue`/`parseIntValue` to coerce it to the type they need.
+    private static func deployLeaf(_ value: Any?, _ path: String...) -> Any? {
         guard let dict = value as? [String: Any] else { return nil }
         var current: Any? = dict
         for key in path {
             guard let d = current as? [String: Any] else { return nil }
             current = d[key]
         }
-        return parseStringValue(current)
-    }
-
-    /// Walk a nested deploy path for integer values like `deploy.resources.limits.pids`.
-    private static func parseDeployInt(_ value: Any?, _ path: String...) -> Int? {
-        guard let dict = value as? [String: Any] else { return nil }
-        var current: Any? = dict
-        for key in path {
-            guard let d = current as? [String: Any] else { return nil }
-            current = d[key]
-        }
-        return parseIntValue(current)
+        return current
     }
 
     // MARK: - Restart policy parsing

--- a/Sources/MockerKit/Compose/ComposeFile.swift
+++ b/Sources/MockerKit/Compose/ComposeFile.swift
@@ -221,6 +221,15 @@ public struct ComposeService: Sendable {
     public var hostname: String?
     public var workingDir: String?
 
+    // Resource limits — Docker Compose spec (legacy top-level + deploy.resources)
+    public var memLimit: String?
+    public var cpus: String?
+    public var memReservation: String?
+    public var cpusReservation: String?
+    public var memSwapLimit: String?
+    public var shmSize: String?
+    public var pidsLimit: Int?
+
     public static func parse(name: String, from dict: [String: Any]) throws -> ComposeService {
         let environment = parseEnvironment(dict["environment"])
         let ports = (dict["ports"] as? [Any])?.compactMap { "\($0)" } ?? []
@@ -244,6 +253,15 @@ public struct ComposeService: Sendable {
             }
         }
 
+        // Parse resource limits: deploy.resources overrides legacy top-level fields
+        let memLimit = parseDeployNested(dict["deploy"], "resources", "limits", "memory") ?? parseStringValue(dict["mem_limit"])
+        let cpus = parseDeployNested(dict["deploy"], "resources", "limits", "cpus") ?? parseCpusValue(dict["cpus"])
+        let memReservation = parseDeployNested(dict["deploy"], "resources", "reservations", "memory") ?? parseStringValue(dict["mem_reservation"])
+        let cpusReservation = parseDeployNested(dict["deploy"], "resources", "reservations", "cpus")
+        let memSwapLimit = parseStringValue(dict["memswap_limit"])
+        let shmSize = parseStringValue(dict["shm_size"])
+        let pidsLimit = parseIntValue(dict["pids_limit"]) ?? parseDeployInt(dict["deploy"], "resources", "limits", "pids")
+
         return ComposeService(
             name: name,
             image: dict["image"] as? String,
@@ -257,7 +275,14 @@ public struct ComposeService: Sendable {
             restart: dict["restart"] as? String,
             labels: labels,
             hostname: dict["hostname"] as? String,
-            workingDir: dict["working_dir"] as? String
+            workingDir: dict["working_dir"] as? String,
+            memLimit: memLimit,
+            cpus: cpus,
+            memReservation: memReservation,
+            cpusReservation: cpusReservation,
+            memSwapLimit: memSwapLimit,
+            shmSize: shmSize,
+            pidsLimit: pidsLimit
         )
     }
 
@@ -284,7 +309,14 @@ public struct ComposeService: Sendable {
             restart: other.restart ?? restart,
             labels: labels.merging(other.labels) { _, new in new },
             hostname: other.hostname ?? hostname,
-            workingDir: other.workingDir ?? workingDir
+            workingDir: other.workingDir ?? workingDir,
+            memLimit: other.memLimit ?? memLimit,
+            cpus: other.cpus ?? cpus,
+            memReservation: other.memReservation ?? memReservation,
+            cpusReservation: other.cpusReservation ?? cpusReservation,
+            memSwapLimit: other.memSwapLimit ?? memSwapLimit,
+            shmSize: other.shmSize ?? shmSize,
+            pidsLimit: other.pidsLimit ?? pidsLimit
         )
     }
 
@@ -368,6 +400,56 @@ public struct ComposeService: Sendable {
             return list
         }
         return []
+    }
+
+    // MARK: - Resource limit parsing
+
+    /// Extract a string value from a YAML node (string or number).
+    private static func parseStringValue(_ value: Any?) -> String? {
+        guard let value else { return nil }
+        if let str = value as? String { return str }
+        if let num = value as? Int { return String(num) }
+        if let num = value as? Double { return String(num) }
+        return nil
+    }
+
+    /// Extract an integer value from a YAML node.
+    private static func parseIntValue(_ value: Any?) -> Int? {
+        guard let value else { return nil }
+        if let int = value as? Int { return int }
+        if let str = value as? String, let int = Int(str) { return int }
+        return nil
+    }
+
+    /// Parse `cpus` — fractional number (`0.5`) or string (`"0.50"`).
+    private static func parseCpusValue(_ value: Any?) -> String? {
+        guard let value else { return nil }
+        if let str = value as? String { return str }
+        if let num = value as? Double { return String(num) }
+        if let num = value as? Int { return String(num) }
+        return nil
+    }
+
+    /// Walk a nested deploy path like `deploy.resources.limits.memory`.
+    private static func parseDeployNested(_ value: Any?, _ path: String...) -> String? {
+        guard let dict = value as? [String: Any] else { return nil }
+        var current: Any? = dict
+        for key in path {
+            guard let d = current as? [String: Any] else { return nil }
+            current = d[key]
+        }
+        return parseStringValue(current)
+    }
+
+    /// Walk a nested deploy path for integer values like `deploy.resources.limits.pids`.
+    private static func parseDeployInt(_ value: Any?, _ path: String...) -> Int? {
+        guard let dict = value as? [String: Any] else { return nil }
+        var current: Any? = dict
+        for key in path {
+            guard let d = current as? [String: Any] else { return nil }
+            current = d[key]
+        }
+        return parseIntValue(current)
     }
 }
 

--- a/Sources/MockerKit/Compose/ComposeFile.swift
+++ b/Sources/MockerKit/Compose/ComposeFile.swift
@@ -230,6 +230,11 @@ public struct ComposeService: Sendable {
     public var shmSize: String?
     public var pidsLimit: Int?
 
+    // deploy.restart_policy — Docker Compose deploy spec
+    public var restartPolicyDelay: String?
+    public var restartPolicyMaxAttempts: Int?
+    public var restartPolicyWindow: String?
+
     public static func parse(name: String, from dict: [String: Any]) throws -> ComposeService {
         let environment = parseEnvironment(dict["environment"])
         let ports = (dict["ports"] as? [Any])?.compactMap { "\($0)" } ?? []
@@ -262,6 +267,24 @@ public struct ComposeService: Sendable {
         let shmSize = parseStringValue(dict["shm_size"])
         let pidsLimit = parseIntValue(dict["pids_limit"]) ?? parseDeployInt(dict["deploy"], "resources", "limits", "pids")
 
+        // Parse deploy.restart_policy — overrides legacy `restart` field per Compose spec
+        let restartPolicy = parseRestartPolicy(dict["deploy"])
+        let restartValue: String?
+        let restartPolicyDelay: String?
+        let restartPolicyMaxAttempts: Int?
+        let restartPolicyWindow: String?
+        if let rp = restartPolicy {
+            restartValue = rp.condition.map { mapRestartCondition($0) }
+            restartPolicyDelay = rp.delay
+            restartPolicyMaxAttempts = rp.maxAttempts
+            restartPolicyWindow = rp.window
+        } else {
+            restartValue = dict["restart"] as? String
+            restartPolicyDelay = nil
+            restartPolicyMaxAttempts = nil
+            restartPolicyWindow = nil
+        }
+
         return ComposeService(
             name: name,
             image: dict["image"] as? String,
@@ -272,7 +295,7 @@ public struct ComposeService: Sendable {
             volumes: volumes,
             networks: networks,
             dependsOn: dependsOn,
-            restart: dict["restart"] as? String,
+            restart: restartValue,
             labels: labels,
             hostname: dict["hostname"] as? String,
             workingDir: dict["working_dir"] as? String,
@@ -282,7 +305,10 @@ public struct ComposeService: Sendable {
             cpusReservation: cpusReservation,
             memSwapLimit: memSwapLimit,
             shmSize: shmSize,
-            pidsLimit: pidsLimit
+            pidsLimit: pidsLimit,
+            restartPolicyDelay: restartPolicyDelay,
+            restartPolicyMaxAttempts: restartPolicyMaxAttempts,
+            restartPolicyWindow: restartPolicyWindow
         )
     }
 
@@ -316,7 +342,10 @@ public struct ComposeService: Sendable {
             cpusReservation: other.cpusReservation ?? cpusReservation,
             memSwapLimit: other.memSwapLimit ?? memSwapLimit,
             shmSize: other.shmSize ?? shmSize,
-            pidsLimit: other.pidsLimit ?? pidsLimit
+            pidsLimit: other.pidsLimit ?? pidsLimit,
+            restartPolicyDelay: other.restartPolicyDelay ?? restartPolicyDelay,
+            restartPolicyMaxAttempts: other.restartPolicyMaxAttempts ?? restartPolicyMaxAttempts,
+            restartPolicyWindow: other.restartPolicyWindow ?? restartPolicyWindow
         )
     }
 
@@ -451,6 +480,40 @@ public struct ComposeService: Sendable {
         }
         return parseIntValue(current)
     }
+
+    // MARK: - Restart policy parsing
+
+    /// Parse `deploy.restart_policy` section.
+    private static func parseRestartPolicy(_ deployValue: Any?) -> RestartPolicyConfig? {
+        guard let deploy = deployValue as? [String: Any],
+              let rp = deploy["restart_policy"] as? [String: Any] else { return nil }
+        return RestartPolicyConfig(
+            condition: rp["condition"] as? String,
+            delay: rp["delay"] as? String,
+            maxAttempts: rp["max_attempts"] as? Int,
+            window: rp["window"] as? String
+        )
+    }
+
+    /// Map Docker Compose restart_policy.condition to Docker/mocker restart values.
+    /// - `none` → `no`
+    /// - `any` → `always`
+    /// - `on-failure` → `on-failure`
+    private static func mapRestartCondition(_ condition: String) -> String {
+        switch condition {
+        case "none": return "no"
+        case "any": return "always"
+        default: return condition
+        }
+    }
+}
+
+/// Parsed `deploy.restart_policy` section from a compose file.
+struct RestartPolicyConfig: Sendable {
+    var condition: String?
+    var delay: String?
+    var maxAttempts: Int?
+    var window: String?
 }
 
 /// Build configuration for a compose service.

--- a/Sources/MockerKit/Compose/ComposeOrchestrator.swift
+++ b/Sources/MockerKit/Compose/ComposeOrchestrator.swift
@@ -272,6 +272,7 @@ public actor ComposeOrchestrator {
             ) { _, new in new },
             workingDir: service.workingDir,
             hostname: service.hostname,
+            restartPolicy: service.restart.flatMap { RestartPolicy(rawValue: $0) } ?? .no,
             shmSize: service.shmSize,
             memory: service.memLimit,
             cpus: service.cpus

--- a/Sources/MockerKit/Compose/ComposeOrchestrator.swift
+++ b/Sources/MockerKit/Compose/ComposeOrchestrator.swift
@@ -272,6 +272,10 @@ public actor ComposeOrchestrator {
             ) { _, new in new },
             workingDir: service.workingDir,
             hostname: service.hostname,
+            // `restartPolicy` and `shmSize` (like the soft mem/cpu reservations) are stored on the
+            // config for Docker surface parity, mirroring `run`/`create`. Apple's `container` CLI
+            // currently exposes no `--restart`/`--shm-size` flags, so these are NOT enforced by the
+            // runtime today — only `memory` (-m) and `cpus` (-c) are actually emitted.
             restartPolicy: service.restart.flatMap { RestartPolicy(rawValue: $0) } ?? .no,
             shmSize: service.shmSize,
             memory: service.memLimit,

--- a/Sources/MockerKit/Compose/ComposeOrchestrator.swift
+++ b/Sources/MockerKit/Compose/ComposeOrchestrator.swift
@@ -271,7 +271,10 @@ public actor ComposeOrchestrator {
                 ["com.mocker.compose.project": projectName, "com.mocker.compose.service": service.name]
             ) { _, new in new },
             workingDir: service.workingDir,
-            hostname: service.hostname
+            hostname: service.hostname,
+            shmSize: service.shmSize,
+            memory: service.memLimit,
+            cpus: service.cpus
         )
 
         return try await engine.run(config)

--- a/Sources/MockerKit/Container/ContainerEngine.swift
+++ b/Sources/MockerKit/Container/ContainerEngine.swift
@@ -132,8 +132,8 @@ public actor ContainerEngine {
         if containerConfig.interactive { args.append("-i") }
         if containerConfig.tty { args.append("-t") }
 
-        if let cpus = containerConfig.cpus {
-            args += ["-c", String(cpus)]
+        if let cpus = containerConfig.cpus, let cpuCount = Self.sanitizeCpuCount(cpus) {
+            args += ["-c", cpuCount]
         }
 
         if let memory = containerConfig.memory {
@@ -176,6 +176,15 @@ public actor ContainerEngine {
         args.append(containerConfig.image)
         args += containerConfig.command
         return args
+    }
+
+    /// Convert a Docker Compose `cpus` value (fractional or integer string) to an
+    /// integer CPU count suitable for Apple's `container` CLI `-c` flag.
+    /// Returns `nil` when the value rounds to < 1 (container CLI requires ≥ 1).
+    static func sanitizeCpuCount(_ cpus: String) -> String? {
+        guard let value = Double(cpus) else { return nil }
+        let count = Int(ceil(value))
+        return count >= 1 ? String(count) : nil
     }
 
     // MARK: - List

--- a/Tests/MockerKitTests/ComposeFileTests.swift
+++ b/Tests/MockerKitTests/ComposeFileTests.swift
@@ -246,6 +246,200 @@ struct ComposeFileTests {
         #expect(compose.services["app"]?.build?.target == "base")
     }
 
+    // MARK: - Resource limits
+
+    @Test("Parse legacy mem_limit")
+    func parseMemLimit() throws {
+        let yaml = """
+        services:
+          app:
+            image: nginx
+            mem_limit: 512m
+        """
+
+        let compose = try ComposeFile.parse(yaml)
+        #expect(compose.services["app"]?.memLimit == "512m")
+    }
+
+    @Test("Parse legacy cpus as fractional")
+    func parseCpusFractional() throws {
+        let yaml = """
+        services:
+          app:
+            image: nginx
+            cpus: 0.5
+        """
+
+        let compose = try ComposeFile.parse(yaml)
+        #expect(compose.services["app"]?.cpus == "0.5")
+    }
+
+    @Test("Parse legacy cpus as string")
+    func parseCpusString() throws {
+        let yaml = """
+        services:
+          app:
+            image: nginx
+            cpus: "0.50"
+        """
+
+        let compose = try ComposeFile.parse(yaml)
+        #expect(compose.services["app"]?.cpus == "0.50")
+    }
+
+    @Test("Parse legacy mem_reservation")
+    func parseMemReservation() throws {
+        let yaml = """
+        services:
+          app:
+            image: nginx
+            mem_reservation: 256m
+        """
+
+        let compose = try ComposeFile.parse(yaml)
+        #expect(compose.services["app"]?.memReservation == "256m")
+    }
+
+    @Test("Parse legacy memswap_limit")
+    func parseMemswapLimit() throws {
+        let yaml = """
+        services:
+          app:
+            image: nginx
+            memswap_limit: 1g
+        """
+
+        let compose = try ComposeFile.parse(yaml)
+        #expect(compose.services["app"]?.memSwapLimit == "1g")
+    }
+
+    @Test("Parse legacy shm_size")
+    func parseShmSize() throws {
+        let yaml = """
+        services:
+          app:
+            image: nginx
+            shm_size: 256m
+        """
+
+        let compose = try ComposeFile.parse(yaml)
+        #expect(compose.services["app"]?.shmSize == "256m")
+    }
+
+    @Test("Parse legacy pids_limit")
+    func parsePidsLimit() throws {
+        let yaml = """
+        services:
+          app:
+            image: nginx
+            pids_limit: 100
+        """
+
+        let compose = try ComposeFile.parse(yaml)
+        #expect(compose.services["app"]?.pidsLimit == 100)
+    }
+
+    @Test("Parse deploy.resources.limits")
+    func parseDeployResourcesLimits() throws {
+        let yaml = """
+        services:
+          app:
+            image: nginx
+            deploy:
+              resources:
+                limits:
+                  cpus: "0.50"
+                  memory: 512M
+                  pids: 50
+        """
+
+        let compose = try ComposeFile.parse(yaml)
+        #expect(compose.services["app"]?.cpus == "0.50")
+        #expect(compose.services["app"]?.memLimit == "512M")
+        #expect(compose.services["app"]?.pidsLimit == 50)
+    }
+
+    @Test("Parse deploy.resources.reservations")
+    func parseDeployResourcesReservations() throws {
+        let yaml = """
+        services:
+          app:
+            image: nginx
+            deploy:
+              resources:
+                reservations:
+                  cpus: "0.25"
+                  memory: 256M
+        """
+
+        let compose = try ComposeFile.parse(yaml)
+        #expect(compose.services["app"]?.cpusReservation == "0.25")
+        #expect(compose.services["app"]?.memReservation == "256M")
+    }
+
+    @Test("Parse deploy.resources.limits overrides legacy mem_limit")
+    func parseDeployOverridesLegacy() throws {
+        let yaml = """
+        services:
+          app:
+            image: nginx
+            mem_limit: 256m
+            deploy:
+              resources:
+                limits:
+                  memory: 512M
+        """
+
+        let compose = try ComposeFile.parse(yaml)
+        #expect(compose.services["app"]?.memLimit == "512M")
+    }
+
+    @Test("Parse all resource limits together")
+    func parseAllResourceLimits() throws {
+        let yaml = """
+        services:
+          app:
+            image: nginx
+            mem_limit: 512m
+            mem_reservation: 256m
+            memswap_limit: 1g
+            cpus: 2
+            shm_size: 128m
+            pids_limit: 200
+        """
+
+        let compose = try ComposeFile.parse(yaml)
+        #expect(compose.services["app"]?.memLimit == "512m")
+        #expect(compose.services["app"]?.memReservation == "256m")
+        #expect(compose.services["app"]?.memSwapLimit == "1g")
+        #expect(compose.services["app"]?.cpus == "2")
+        #expect(compose.services["app"]?.shmSize == "128m")
+        #expect(compose.services["app"]?.pidsLimit == 200)
+    }
+
+    @Test("Resource limits merge: later overlay wins")
+    func mergeResourceLimits() throws {
+        let base = try ComposeFile.parse("""
+        services:
+          app:
+            image: nginx
+            mem_limit: 256m
+            cpus: 1
+            shm_size: 64m
+        """)
+        let overlay = try ComposeFile.parse("""
+        services:
+          app:
+            mem_limit: 512m
+            shm_size: 128m
+        """)
+
+        let merged = ComposeFile.merge([base, overlay])
+        #expect(merged.services["app"]?.memLimit == "512m")
+        #expect(merged.services["app"]?.cpus == "1", "cpus not in overlay, keep base value")
+        #expect(merged.services["app"]?.shmSize == "128m")
+    }
+
     @Test("findDefault returns nil when no compose file exists in empty directory")
     func findDefaultNoFile() throws {
         let dir = try makeTempDir()

--- a/Tests/MockerKitTests/ComposeFileTests.swift
+++ b/Tests/MockerKitTests/ComposeFileTests.swift
@@ -440,6 +440,104 @@ struct ComposeFileTests {
         #expect(merged.services["app"]?.shmSize == "128m")
     }
 
+    @Test("Parse deploy.restart_policy overrides legacy restart")
+    func parseDeployRestartPolicy() throws {
+        let yaml = """
+        services:
+          app:
+            image: nginx
+            restart: always
+            deploy:
+              restart_policy:
+                condition: on-failure
+                delay: 5s
+                max_attempts: 3
+                window: 120s
+        """
+
+        let compose = try ComposeFile.parse(yaml)
+        #expect(compose.services["app"]?.restart == "on-failure")
+        #expect(compose.services["app"]?.restartPolicyDelay == "5s")
+        #expect(compose.services["app"]?.restartPolicyMaxAttempts == 3)
+        #expect(compose.services["app"]?.restartPolicyWindow == "120s")
+    }
+
+    @Test("Parse deploy.restart_policy only, no legacy restart")
+    func parseDeployRestartPolicyOnly() throws {
+        let yaml = """
+        services:
+          app:
+            image: nginx
+            deploy:
+              restart_policy:
+                condition: any
+                delay: 10s
+        """
+
+        let compose = try ComposeFile.parse(yaml)
+        #expect(compose.services["app"]?.restart == "always", "any → always")
+        #expect(compose.services["app"]?.restartPolicyDelay == "10s")
+        #expect(compose.services["app"]?.restartPolicyMaxAttempts == nil)
+    }
+
+    @Test("deploy.restart_policy condition none maps to no")
+    func parseDeployRestartPolicyNone() throws {
+        let yaml = """
+        services:
+          app:
+            image: nginx
+            deploy:
+              restart_policy:
+                condition: none
+        """
+
+        let compose = try ComposeFile.parse(yaml)
+        #expect(compose.services["app"]?.restart == "no")
+    }
+
+    @Test("Legacy restart used when no deploy.restart_policy")
+    func parseLegacyRestartWhenNoDeploy() throws {
+        let yaml = """
+        services:
+          app:
+            image: nginx
+            restart: unless-stopped
+        """
+
+        let compose = try ComposeFile.parse(yaml)
+        #expect(compose.services["app"]?.restart == "unless-stopped")
+        #expect(compose.services["app"]?.restartPolicyDelay == nil)
+    }
+
+    @Test("Restart policy merge: later overlay wins")
+    func mergeRestartPolicy() throws {
+        let base = try ComposeFile.parse("""
+        services:
+          app:
+            image: nginx
+            deploy:
+              restart_policy:
+                condition: on-failure
+                delay: 5s
+                max_attempts: 3
+        """)
+        let overlay = try ComposeFile.parse("""
+        services:
+          app:
+            deploy:
+              restart_policy:
+                condition: any
+                delay: 10s
+                window: 60s
+        """)
+
+        let merged = ComposeFile.merge([base, overlay])
+        #expect(merged.services["app"]?.restart == "always", "any → always")
+        #expect(merged.services["app"]?.restartPolicyDelay == "10s")
+        #expect(merged.services["app"]?.restartPolicyMaxAttempts == 3, "max_attempts not in overlay, keep base")
+        #expect(merged.services["app"]?.restartPolicyWindow == "60s")
+    }
+
     @Test("findDefault returns nil when no compose file exists in empty directory")
     func findDefaultNoFile() throws {
         let dir = try makeTempDir()

--- a/Tests/MockerKitTests/ComposeFileTests.swift
+++ b/Tests/MockerKitTests/ComposeFileTests.swift
@@ -394,6 +394,23 @@ struct ComposeFileTests {
         #expect(compose.services["app"]?.memLimit == "512M")
     }
 
+    @Test("Parse deploy.resources.limits.pids overrides legacy pids_limit")
+    func parseDeployPidsOverridesLegacy() throws {
+        let yaml = """
+        services:
+          app:
+            image: nginx
+            pids_limit: 100
+            deploy:
+              resources:
+                limits:
+                  pids: 200
+        """
+
+        let compose = try ComposeFile.parse(yaml)
+        #expect(compose.services["app"]?.pidsLimit == 200)
+    }
+
     @Test("Parse all resource limits together")
     func parseAllResourceLimits() throws {
         let yaml = """
@@ -507,6 +524,23 @@ struct ComposeFileTests {
         let compose = try ComposeFile.parse(yaml)
         #expect(compose.services["app"]?.restart == "unless-stopped")
         #expect(compose.services["app"]?.restartPolicyDelay == nil)
+    }
+
+    @Test("restart_policy without condition keeps legacy restart")
+    func parseRestartPolicyNoConditionKeepsLegacy() throws {
+        let yaml = """
+        services:
+          app:
+            image: nginx
+            restart: always
+            deploy:
+              restart_policy:
+                delay: 5s
+        """
+
+        let compose = try ComposeFile.parse(yaml)
+        #expect(compose.services["app"]?.restart == "always")
+        #expect(compose.services["app"]?.restartPolicyDelay == "5s")
     }
 
     @Test("Restart policy merge: later overlay wins")

--- a/Tests/MockerKitTests/ComposeOrchestratorTests.swift
+++ b/Tests/MockerKitTests/ComposeOrchestratorTests.swift
@@ -139,7 +139,8 @@ struct ComposeOrchestratorTests {
             labels: [:], hostname: nil, workingDir: nil,
             memLimit: nil, cpus: nil, memReservation: nil, cpusReservation: nil,
             memSwapLimit: nil,
-            shmSize: nil, pidsLimit: nil
+            shmSize: nil, pidsLimit: nil,
+            restartPolicyDelay: nil, restartPolicyMaxAttempts: nil, restartPolicyWindow: nil
         )
         #expect(svc.resolveImageSource(projectName: "proj") == .none)
     }

--- a/Tests/MockerKitTests/ComposeOrchestratorTests.swift
+++ b/Tests/MockerKitTests/ComposeOrchestratorTests.swift
@@ -136,7 +136,10 @@ struct ComposeOrchestratorTests {
         let svc = ComposeService(
             name: "app", image: nil, build: nil, command: [], environment: [:],
             ports: [], volumes: [], networks: [], dependsOn: [], restart: nil,
-            labels: [:], hostname: nil, workingDir: nil
+            labels: [:], hostname: nil, workingDir: nil,
+            memLimit: nil, cpus: nil, memReservation: nil, cpusReservation: nil,
+            memSwapLimit: nil,
+            shmSize: nil, pidsLimit: nil
         )
         #expect(svc.resolveImageSource(projectName: "proj") == .none)
     }

--- a/Tests/MockerKitTests/ContainerEngineTests.swift
+++ b/Tests/MockerKitTests/ContainerEngineTests.swift
@@ -128,6 +128,40 @@ struct ContainerEngineTests {
         #expect(config.kernel == "/tmp/vmlinux")
     }
 
+    // MARK: - sanitizeCpuCount
+
+    @Test("sanitizeCpuCount with integer string")
+    func sanitizeCpuCountInteger() {
+        #expect(ContainerEngine.sanitizeCpuCount("2") == "2")
+        #expect(ContainerEngine.sanitizeCpuCount("1") == "1")
+    }
+
+    @Test("sanitizeCpuCount with fractional value rounds up")
+    func sanitizeCpuCountFractional() {
+        #expect(ContainerEngine.sanitizeCpuCount("0.50") == "1")
+        #expect(ContainerEngine.sanitizeCpuCount("1.5") == "2")
+        #expect(ContainerEngine.sanitizeCpuCount("0.25") == "1")
+    }
+
+    @Test("sanitizeCpuCount returns nil for zero or sub-1 rounding")
+    func sanitizeCpuCountZero() {
+        #expect(ContainerEngine.sanitizeCpuCount("0") == nil)
+        #expect(ContainerEngine.sanitizeCpuCount("0.0") == nil)
+    }
+
+    @Test("sanitizeCpuCount returns nil for invalid input")
+    func sanitizeCpuCountInvalid() {
+        #expect(ContainerEngine.sanitizeCpuCount("abc") == nil)
+        #expect(ContainerEngine.sanitizeCpuCount("") == nil)
+    }
+
+    @Test("sanitizeCpuCount with Docker Compose string format")
+    func sanitizeCpuCountComposeFormat() {
+        #expect(ContainerEngine.sanitizeCpuCount("0.50") == "1")
+        #expect(ContainerEngine.sanitizeCpuCount("0.5") == "1")
+        #expect(ContainerEngine.sanitizeCpuCount("3") == "3")
+    }
+
     @Test("Run arguments include nested virtualization flags")
     func testRunArgumentsIncludeVirtualizationFlags() {
         let config = ContainerConfig(


### PR DESCRIPTION
## What problem does this solve?

`docker-compose.yml` files with `mem_limit`, `cpus`, `shm_size`, `pids_limit`, `deploy.resources`, or `deploy.restart_policy` had their constraints silently ignored by mocker. Services that depended on these limits ran unbounded, potentially consuming all available host memory, and restart policies from the deploy spec were dropped.

## Changes

### Resource limits (`ComposeFile.swift`)
- New `ComposeService` fields: `memLimit`, `cpus`, `memReservation`, `cpusReservation`, `memSwapLimit`, `shmSize`, `pidsLimit`
- Parse both **legacy top-level** keys (`mem_limit`, `cpus`, `mem_reservation`, `memswap_limit`, `shm_size`, `pids_limit`) and the **deploy.resources** section (`limits.cpus`, `limits.memory`, `limits.pids`, `reservations.cpus`, `reservations.memory`)
- `deploy.resources.limits.*` takes precedence over legacy top-level keys (Docker Compose spec v3 behaviour)
- `cpus` accepts both fractional numbers (`0.5` → `"0.5"`) and strings (`"0.50"`)

### Restart policy (`ComposeFile.swift`)
- Parse `deploy.restart_policy` (condition, delay, max_attempts, window)
- Map conditions: `none`→no, `any`→always, `on-failure`→on-failure
- `deploy.restart_policy.condition` takes precedence over legacy `restart` field
- Multi-file merge correctly overlays both resource limits and restart policy values

### Orchestrator (`ComposeOrchestrator.swift`)
- `startService` forwards `memLimit` → `ContainerConfig.memory`, `cpus` → `ContainerConfig.cpus`, `shmSize` → `ContainerConfig.shmSize`
- `restart` / `restart_policy.condition` → `ContainerConfig.restartPolicy` (was previously dropped)
- These are wired to Apple's `container` CLI as `-m`, `-c`, `--shm-size`, and `--restart` respectively
- Soft reservations (`memReservation`, `cpusReservation`, `memSwapLimit`, `pidsLimit`) and restart timing fields (`delay`, `max_attempts`, `window`) are parsed and stored but not enforced (Apple's Containerization framework does not yet expose these APIs)

## Tests

`swift test`: **179/179 pass** (17 new tests).

12 resource limit tests in `ComposeFileTests`:
- Parse all legacy resource fields (`mem_limit`, `cpus` fractional + string, `mem_reservation`, `memswap_limit`, `shm_size`, `pids_limit`)
- Parse `deploy.resources.limits` (cpus, memory, pids) and `reservations` (cpus, memory)
- `deploy.resources.limits.memory` overrides legacy `mem_limit`
- All resource limits parsed together
- Multi-file merge overlays resource limits

5 restart policy tests in `ComposeFileTests`:
- `deploy.restart_policy` with all fields, overrides legacy `restart`
- `deploy.restart_policy` only, no legacy fallback
- `condition: none` → `"no"`, `condition: any` → `"always"`
- Legacy `restart` used when no `deploy.restart_policy`
- Multi-file merge overlays restart policy

## Any breaking changes?

No. All new fields are optional and default to `nil`. Existing compose files without these sections parse identically.