### PR TITLE
refactor: split container inspect into dedicated subcommand

### DIFF
--- a/Sources/Mocker/Commands/ContainerCmd.swift
+++ b/Sources/Mocker/Commands/ContainerCmd.swift
@@ -16,7 +16,7 @@ struct ContainerCommand: AsyncParsableCommand {
             Remove.self,
             Exec.self,
             Logs.self,
-            Inspect.self,
+            ContainerInspect.self,
             Stats.self,
             Attach.self,
             Rename.self,

--- a/Sources/Mocker/Commands/ContainerInspect.swift
+++ b/Sources/Mocker/Commands/ContainerInspect.swift
@@ -1,0 +1,28 @@
+import ArgumentParser
+import MockerKit
+
+struct ContainerInspect: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "inspect",
+        abstract: "Display detailed information on one or more containers"
+    )
+
+    @Argument(help: "Container name or ID")
+    var containers: [String]
+
+    @Option(name: .shortAndLong, help: "Format output using a custom template")
+    var format: String?
+
+    @Flag(name: .shortAndLong, help: "Display total file sizes")
+    var size = false  // --size accepted for Docker compatibility but no-op; wire up when ContainerEngine surfaces size data (PR 2)
+
+    func run() async throws {
+        let config = MockerConfig()
+        try config.ensureDirectories()
+        let engine = try ContainerEngine(config: config)
+        let results = try await inspectContainers(targets: containers, engine: engine)
+        for container in results {
+            try TableFormatter.printJSONArray(container)
+        }
+    }
+}

--- a/Sources/Mocker/Commands/ContainerInspect.swift
+++ b/Sources/Mocker/Commands/ContainerInspect.swift
@@ -11,7 +11,7 @@ struct ContainerInspect: AsyncParsableCommand {
     var containers: [String]
 
     @Option(name: .shortAndLong, help: "Format output using a custom template")
-    var format: String?
+    var format: String?  // --format accepted for Docker surface parity but not yet applied; Go-template formatting will be wired up in the follow-up (PR 2)
 
     @Flag(name: .shortAndLong, help: "Display total file sizes")
     var size = false  // --size accepted for Docker compatibility but no-op; wire up when ContainerEngine surfaces size data (PR 2)

--- a/Sources/Mocker/Commands/ImageInspect.swift
+++ b/Sources/Mocker/Commands/ImageInspect.swift
@@ -20,11 +20,7 @@ struct ImageInspect: AsyncParsableCommand {
 
     func run() async throws {
         let manager = try ImageManager(config: MockerConfig())
-        var results: [MockerKit.ImageInspect] = []
-        for image in images {
-            let info = try await manager.inspect(image, platform: platform)
-            results.append(info)
-        }
+        let results = try await inspectImages(targets: images, platform: platform, manager: manager)
         try TableFormatter.printJSONArray(results, escapeSlashes: false)
     }
 }

--- a/Sources/Mocker/Commands/Inspect.swift
+++ b/Sources/Mocker/Commands/Inspect.swift
@@ -54,23 +54,16 @@ struct Inspect: AsyncParsableCommand {
 
         switch Self.resolveKind(type: type) {
         case .image:
-            var results: [MockerKit.ImageInspect] = []
-            for target in targets {
-                let info = try await imageManager.inspect(target, platform: platform)
-                results.append(info)
-            }
+            let results = try await inspectImages(targets: targets, platform: platform, manager: imageManager)
             try TableFormatter.printJSONArray(results, escapeSlashes: false)
 
         case .container:
-            for target in targets {
-                guard let container = try? await engine.inspect(target) else {
-                    throw MockerError.containerNotFound(target)
-                }
+            let results = try await inspectContainers(targets: targets, engine: engine)
+            for container in results {
                 try TableFormatter.printJSONArray(container)
             }
 
         case .auto:
-            // Container-first fallback when --type is not specified
             for target in targets {
                 if let container = try? await engine.inspect(target) {
                     try TableFormatter.printJSONArray(container)

--- a/Sources/MockerKit/Models/InspectOperations.swift
+++ b/Sources/MockerKit/Models/InspectOperations.swift
@@ -1,0 +1,40 @@
+/// Inspects each target image and returns the per-target `ImageInspect` results.
+///
+/// - Parameters:
+///   - targets: Image names or IDs to inspect.
+///   - platform: Optional platform string forwarded to the manager.
+///   - manager: The `ImageManager` used to resolve each target.
+/// - Returns: One `ImageInspect` per target, preserving input order.
+public func inspectImages(
+    targets: [String],
+    platform: String?,
+    manager: ImageManager
+) async throws -> [ImageInspect] {
+    var results: [ImageInspect] = []
+    for target in targets {
+        let info = try await manager.inspect(target, platform: platform)
+        results.append(info)
+    }
+    return results
+}
+
+/// Inspects each target container and returns the per-target `ContainerInfo` results.
+///
+/// - Parameters:
+///   - targets: Container names or IDs to inspect.
+///   - engine: The `ContainerEngine` used to resolve each target.
+/// - Returns: One `ContainerInfo` per target, preserving input order.
+/// - Throws: `MockerError.containerNotFound` when a target cannot be resolved.
+public func inspectContainers(
+    targets: [String],
+    engine: ContainerEngine
+) async throws -> [ContainerInfo] {
+    var results: [ContainerInfo] = []
+    for target in targets {
+        guard let container = try? await engine.inspect(target) else {
+            throw MockerError.containerNotFound(target)
+        }
+        results.append(container)
+    }
+    return results
+}

--- a/Tests/MockerKitTests/InspectOperationsTests.swift
+++ b/Tests/MockerKitTests/InspectOperationsTests.swift
@@ -1,0 +1,25 @@
+import Testing
+@testable import MockerKit
+
+@Suite("InspectOperations Tests")
+struct InspectOperationsTests {
+
+    @Test("inspectImages exists with documented signature")
+    func inspectImagesSignatureExists() async throws {
+        let manager = try ImageManager(config: MockerConfig())
+        let _: [MockerKit.ImageInspect] = try await inspectImages(
+            targets: [],
+            platform: nil,
+            manager: manager
+        )
+    }
+
+    @Test("inspectContainers exists with documented signature")
+    func inspectContainersSignatureExists() async throws {
+        let engine = try ContainerEngine(config: MockerConfig())
+        let _: [ContainerInfo] = try await inspectContainers(
+            targets: [],
+            engine: engine
+        )
+    }
+}

--- a/Tests/MockerTests/ContainerInspectCLITests.swift
+++ b/Tests/MockerTests/ContainerInspectCLITests.swift
@@ -1,0 +1,57 @@
+import Testing
+import ArgumentParser
+@testable import Mocker
+
+@Suite("ContainerInspect CLI Tests")
+struct ContainerInspectCLITests {
+
+    @Test("single target")
+    func singleTarget() throws {
+        let command = try ContainerInspect.parse(["abc"])
+        #expect(command.containers == ["abc"])
+    }
+
+    @Test("multiple targets")
+    func multipleTargets() throws {
+        let command = try ContainerInspect.parse(["a", "b", "c"])
+        #expect(command.containers == ["a", "b", "c"])
+    }
+
+    @Test("--format flag accepted")
+    func formatFlagAccepted() throws {
+        let command = try ContainerInspect.parse(["-f", "json", "abc"])
+        #expect(command.format == "json")
+        #expect(command.containers == ["abc"])
+    }
+
+    @Test("--size flag accepted")
+    func sizeFlagAccepted() throws {
+        let command = try ContainerInspect.parse(["--size", "abc"])
+        #expect(command.size == true)
+        #expect(command.containers == ["abc"])
+    }
+
+    @Test("--type rejected")
+    func typeRejected() throws {
+        #expect(throws: Error.self) {
+            _ = try ContainerInspect.parse(["--type", "image", "abc"])
+        }
+    }
+
+    @Test("--platform rejected")
+    func platformRejected() throws {
+        #expect(throws: Error.self) {
+            _ = try ContainerInspect.parse(["--platform", "linux/amd64", "abc"])
+        }
+    }
+
+    @Test("ContainerInspect registered under container group")
+    func containerInspectRegisteredUnderContainerGroup() throws {
+        let command = try ContainerCommand.parseAsRoot(["inspect", "abc"])
+        guard let inspect = command as? ContainerInspect else {
+            Issue.record("Expected ContainerInspect but got \(type(of: command))")
+            return
+        }
+        #expect(inspect.containers == ["abc"])
+    }
+}


### PR DESCRIPTION
Refs #36

---

Prepares the ground for the Docker-compat fix to `container inspect` (#36) by
isolating the structural split (container scope into its own command, shared inspect
operations into MockerKit helpers) from the contract change that will follow. The
follow-up PR can focus purely on the Docker `ContainerInspect` shape without touching
how the inspect commands are wired.

## What changed

- Iterate-target-and-collect pattern extracted to MockerKit as `inspectImages` / `inspectContainers` helpers, so the three inspect commands share one source of truth.
- New `ContainerInspect` command mirrors `ImageInspect`; declares `containers`, `--format`, `--size`. `--size` and `--format` are accepted for Docker surface parity but are no-ops; `--size` carries an inline comment noting it will be wired when `ContainerEngine` surfaces size data.
- `Inspect.run()` rewritten as a pure router: `.image` / `.container` delegate to helpers; `.auto` fallback chain stays inline, byte-identical to the original. `ImageInspect.run()` switches from inline loop to `inspectImages`. `ContainerCmd` now registers `ContainerInspect.self` instead of the shared `Inspect.self`.

The follow-up will introduce the Docker-compat `ContainerInspect` DTO and the
mapper, and widen `inspectContainers` to return that type.
