### PR TITLE
docs(readme): replace stale What's New list with CHANGELOG link

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,47 +40,7 @@ Your existing `docker-compose.yml` works as-is.
 
 ## What's New
 
-### v0.4.0 — Docker-compatible image inspect
-- **Docker-compatible `ImageInspect` output** — `mocker image inspect` and `mocker inspect --type image` now emit the same Docker-shaped JSON array with PascalCase keys.
-- **Real image metadata** — image inspect now reads OCI manifest/config data for `Size`, `Created`, `Architecture`, `Os`, `Config`, `RootFS`, repo tags, and repo digests instead of returning stubbed values.
-- **Inspect routing fixes** — `mocker inspect --type image|container` now validates type values, and `--platform` is honored for image inspection.
-- **Compose fixes** — published ports are forwarded correctly and `compose -f ... up` works when `-f` appears before the subcommand.
-- **BREAKING**: image inspect output changed from the old lowercase `ImageInfo` object shape to Docker-compatible `ImageInspect` arrays; `MockerKit.ImageManager.inspect(_:platform:)` now returns `ImageInspect`.
-
-### v0.3.0 — Multi-arch images
-- **`mocker manifest`** subcommand group — `create`, `inspect`, `add`, `rm`, `annotate`, `push` for assembling and publishing OCI image indexes (multi-arch manifest lists). Pure-Swift via Containerization, no skopeo required (closes #9, #11)
-- **Multi-platform builds** — `mocker build --platform linux/amd64 --platform linux/arm64 -t img:tag .` produces a single multi-arch image
-- **`--platform` wired through `pull`/`push`** — hardcoded `arm64` removed; specify any supported platform
-- **Apple container CLI store auto-detection** — mocker reads from `~/Library/Application Support/com.apple.container/` by default
-- **BREAKING**: `MockerKit` consumers calling `ImageManager.build(platform:)` must migrate to `build(platforms:)`
-- Exotic architectures (ppc64le, s390x, riscv64) — layer-only Dockerfiles work; `RUN` steps blocked upstream by [apple/container#1496](https://github.com/apple/container/issues/1496) — see "Building for exotic architectures"
-
-### v0.2.1 — Nested virtualization
-- **`--virtualization` / `--kernel`** for `mocker run` and `mocker create` — expose nested virtualization to containers (closes #4)
-
-### v0.2.0 — Ground Truth
-- **Honesty layer** — unsupported commands return explicit errors instead of silently mutating state
-- **Security**: shell-injection fixes in `copyToContainer` and compose hostname injection
-- Forward Apple CLI flags in `run` (`-i`, `-t`, `--cidfile`, `--rm`, `--platform`, ...) and `build` (`--label`, `--quiet`, `--progress`, `--output`)
-- Test infrastructure: `ProcessRunner` protocol + 16 new tests (42 total)
-
-### v0.1.9 — Full Docker CLI Flag Compatibility
-- **111 commands/subcommands** with Docker-matching flags
-- `run`/`create`: ~50 new flags (`--attach`, `--cpu-shares`, `--gpus`, `--init`, `--memory`, `--privileged`, `--restart`, `--shm-size`, `--ulimit`, etc.)
-- `build`: ~25 BuildKit/Buildx flags (`--cache-from`, `--load`, `--push`, `--secret`, `--ssh`, etc.)
-- `compose`: ~200+ flags across 22 subcommands
-- New commands: `commit`, `container prune`, `container export`, `image rm/inspect/prune`
-- Full [COMMANDS.md](COMMANDS.md) reference and [CHANGELOG.md](CHANGELOG.md) added
-
-### v0.1.8 — `--env-file` support
-- **`mocker run --env-file .env`** — load environment variables from file, just like Docker
-
-### v0.1.7 — Compose improvements & `--rm` flag
-- **`mocker run --rm`** — auto-remove container on exit
-- `compose.yaml` / `compose.yml` recognized as default compose file
-- Compose `${VAR:-default}` variable substitution fix
-
-> See [CHANGELOG.md](CHANGELOG.md) for the full version history.
+See the **[CHANGELOG](CHANGELOG.md)** for the full, always-current release history — it is regenerated automatically on every release.
 
 ## Features
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -37,39 +37,7 @@ mocker exec -it my-app sh
 
 ## 最新更新
 
-### v0.4.0 — Docker 兼容的镜像检查
-- **Docker 兼容的 `ImageInspect` 输出** — `mocker image inspect` 和 `mocker inspect --type image` 现在输出相同的 Docker 风格 JSON 数组，并使用 PascalCase 字段名。
-- **真实镜像元数据** — 镜像检查会读取 OCI manifest/config 中的 `Size`、`Created`、`Architecture`、`Os`、`Config`、`RootFS`、repo tags 和 repo digests，不再返回占位值。
-- **Inspect 路由修复** — `mocker inspect --type image|container` 会校验类型值，镜像检查也会正确处理 `--platform`。
-- **Compose 修复** — 发布端口会被正确转发，且 `compose -f ... up` 支持在子命令前传入 `-f`。
-- **BREAKING**：镜像检查输出从旧的 lowercase `ImageInfo` 对象变为 Docker 兼容的 `ImageInspect` 数组；`MockerKit.ImageManager.inspect(_:platform:)` 现在返回 `ImageInspect`。
-
-### v0.2.1 — 嵌套虚拟化
-- **`--virtualization` / `--kernel`** 适用于 `mocker run` 和 `mocker create` — 向容器暴露嵌套虚拟化能力（closes #4）
-
-### v0.2.0 — Ground Truth
-- **诚实层** — 不支持的命令返回明确错误，不再静默修改本地状态
-- **安全**：修复 `copyToContainer` 和 compose 主机名注入中的 shell 注入漏洞
-- 在 `run`（`-i`、`-t`、`--cidfile`、`--rm`、`--platform` 等）和 `build`（`--label`、`--quiet`、`--progress`、`--output`）中转发 Apple CLI 参数
-- 测试基础设施：`ProcessRunner` 协议 + 16 个新测试（共 42 个）
-
-### v0.1.9 — 完整 Docker CLI 参数兼容
-- **111 个命令/子命令**与 Docker 参数匹配
-- `run`/`create`：新增约 50 个参数（`--attach`、`--cpu-shares`、`--gpus`、`--init`、`--memory`、`--privileged`、`--restart`、`--shm-size`、`--ulimit` 等）
-- `build`：新增约 25 个 BuildKit/Buildx 参数（`--cache-from`、`--load`、`--push`、`--secret`、`--ssh` 等）
-- `compose`：22 个子命令共新增 200+ 个参数
-- 新命令：`commit`、`container prune`、`container export`、`image rm/inspect/prune`
-- 添加完整的 [COMMANDS.md](COMMANDS.md) 参考文档和 [CHANGELOG.md](CHANGELOG.md)
-
-### v0.1.8 — `--env-file` 支持
-- **`mocker run --env-file .env`** — 从文件加载环境变量，与 Docker 用法一致
-
-### v0.1.7 — Compose 改进 & `--rm` 参数
-- **`mocker run --rm`** — 容器退出后自动删除
-- `compose.yaml` / `compose.yml` 现已被识别为默认 compose 文件
-- Compose `${VAR:-default}` 变量替换修复
-
-> 查看 [CHANGELOG.md](CHANGELOG.md) 了解完整版本历史。
+完整且始终最新的版本历史请查看 **[CHANGELOG](CHANGELOG.md)** — 每次发布都会自动重新生成。
 
 ## 功能特性
 


### PR DESCRIPTION
The README `## What's New` section was hand-maintained with no release-please marker, so it never updated and was frozen at v0.4.0 while releases moved on (most recently v0.5.1).

This points readers to the auto-generated `CHANGELOG.md` (single source of truth) instead, so it can never go stale again. Same change applied to `README.zh-CN.md`.

Docs-only; no code touched (net -74 lines).