### PR TITLE
fix: decode Apple inspect state object and nested ipv4 address

### DIFF
--- a/Sources/MockerKit/Container/ContainerEngine.swift
+++ b/Sources/MockerKit/Container/ContainerEngine.swift
@@ -519,23 +519,8 @@ public actor ContainerEngine {
         if let data = output.data(using: .utf8),
            let arr = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]],
            let first = arr.first,
-           let cfg = first["configuration"] as? [String: Any] {
-            let status = first["status"] as? String ?? "running"
-            let networks = first["networks"] as? [[String: Any]] ?? []
-            let addr = networks.first?["address"] as? String ?? ""
-
-            return ContainerInfo(
-                id: (cfg["id"] as? String) ?? id,
-                name: name,  // Use our assigned name, not hostname from inspect
-                image: config.image,
-                state: status == "running" ? .running : .exited,
-                status: status == "running" ? "Up Less than a second" : "Exited (0)",
-                created: Date(),
-                ports: config.ports,
-                labels: config.labels,
-                command: config.command.joined(separator: " "),
-                networkAddress: addr
-            )
+           let info = ContainerEngine.decodeInspect(first, id: id, name: name, config: config) {
+            return info
         }
 
         // Fallback if inspect fails
@@ -630,6 +615,40 @@ public struct ContainerStats: Sendable {
         self.blockIn = blockIn
         self.blockOut = blockOut
         self.pids = pids
+    }
+}
+
+// MARK: - Inspect Decode
+
+extension ContainerEngine {
+    static func decodeInspect(
+        _ first: [String: Any],
+        id: String,
+        name: String,
+        config: ContainerConfig
+    ) -> ContainerInfo? {
+        guard let cfg = first["configuration"] as? [String: Any] else { return nil }
+        let statusObj = first["status"] as? [String: Any]
+        let stateStr = (statusObj?["state"] as? String) ?? "running"
+        let state: ContainerState = stateStr == "stopped" ? .stopped : .running
+        let statusDisplay = state == .running
+            ? "Up Less than a second"
+            : ContainerState.exited.displayString
+        let networks = (statusObj?["networks"] as? [[String: Any]]) ?? []
+        let rawAddr = (networks.first?["ipv4Address"] as? String) ?? ""
+        let addr = rawAddr.split(separator: "/").first.map(String.init) ?? rawAddr
+        return ContainerInfo(
+            id: (cfg["id"] as? String) ?? id,
+            name: name,
+            image: config.image,
+            state: state,
+            status: statusDisplay,
+            created: Date(),
+            ports: config.ports,
+            labels: config.labels,
+            command: config.command.joined(separator: " "),
+            networkAddress: addr
+        )
     }
 }
 

--- a/Sources/MockerKit/Container/ContainerEngine.swift
+++ b/Sources/MockerKit/Container/ContainerEngine.swift
@@ -204,7 +204,7 @@ public actor ContainerEngine {
                 containers[i].status = "Up"
             } else if containers[i].state == .running {
                 containers[i].state = .exited
-                containers[i].status = "Exited (0)"
+                containers[i].status = ContainerState.exited.displayString
                 try await store.save(containers[i])
             }
         }
@@ -232,7 +232,7 @@ public actor ContainerEngine {
 
         var updated = container
         updated.state = .exited
-        updated.status = "Exited (0)"
+        updated.status = ContainerState.exited.displayString
         try await store.save(updated)
         return updated
     }

--- a/Tests/MockerKitTests/ContainerEngineDecodeInspectTests.swift
+++ b/Tests/MockerKitTests/ContainerEngineDecodeInspectTests.swift
@@ -1,0 +1,140 @@
+import Testing
+import Foundation
+@testable import MockerKit
+
+@Suite("ContainerEngine.decodeInspect Tests")
+struct ContainerEngineDecodeInspectTests {
+
+    // MARK: - Helpers
+
+    private func makeConfig(image: String = "alpine:latest") -> ContainerConfig {
+        ContainerConfig(image: image)
+    }
+
+    private func makeDict(
+        state: String? = "running",
+        ipv4Address: String? = "10.0.0.1/24",
+        networks: [[String: Any]]? = nil,
+        configID: String = "abc123def456ghi"
+    ) -> [String: Any] {
+        var statusObj: [String: Any] = [:]
+        if let state { statusObj["state"] = state }
+        let nets: [[String: Any]]
+        if let networks {
+            nets = networks
+        } else if let ip = ipv4Address {
+            nets = [["ipv4Address": ip]]
+        } else {
+            nets = []
+        }
+        statusObj["networks"] = nets
+        return [
+            "configuration": ["id": configID] as [String: Any],
+            "status": statusObj
+        ]
+    }
+
+    // MARK: - Happy path
+
+    @Test("decodeInspect running container with CIDR network returns running state and stripped IP")
+    func decodeInspect_runningContainerWithCIDRNetwork_returnsRunningStateAndStrippedIP() {
+        let dict = makeDict(state: "running", ipv4Address: "10.0.0.1/24")
+        let config = makeConfig()
+        let result = ContainerEngine.decodeInspect(dict, id: "fallback-id", name: "my-container", config: config)
+        #expect(result != nil)
+        #expect(result?.state == .running)
+        #expect(result?.status == "Up Less than a second")
+        #expect(result?.networkAddress == "10.0.0.1")
+        #expect(result?.name == "my-container")
+    }
+
+    // MARK: - State mapping
+
+    @Test("decodeInspect stopped state returns exited status")
+    func decodeInspect_stoppedState_returnsExitedStatus() {
+        let dict = makeDict(state: "stopped", ipv4Address: nil)
+        let config = makeConfig()
+        let result = ContainerEngine.decodeInspect(dict, id: "id1", name: "ctn", config: config)
+        #expect(result?.state == .stopped)
+        #expect(result?.status == ContainerState.exited.displayString)
+    }
+
+    @Test("decodeInspect unknown state falls back to running")
+    func decodeInspect_unknownState_fallsBackToRunning() {
+        let dict = makeDict(state: "paused", ipv4Address: nil)
+        let config = makeConfig()
+        let result = ContainerEngine.decodeInspect(dict, id: "id1", name: "ctn", config: config)
+        #expect(result?.state == .running)
+    }
+
+    @Test("decodeInspect missing status key falls back to running and empty network")
+    func decodeInspect_missingStatusKey_fallsBackToRunning() {
+        let dict: [String: Any] = [
+            "configuration": ["id": "abc"] as [String: Any]
+        ]
+        let config = makeConfig()
+        let result = ContainerEngine.decodeInspect(dict, id: "fallback", name: "ctn", config: config)
+        #expect(result?.state == .running)
+        #expect(result?.networkAddress == "")
+    }
+
+    // MARK: - Network decode + CIDR
+
+    @Test("decodeInspect plain IP returned as-is")
+    func decodeInspect_plainIP_returnedAsIs() {
+        let dict = makeDict(state: "running", ipv4Address: "10.0.0.1")
+        let config = makeConfig()
+        let result = ContainerEngine.decodeInspect(dict, id: "id1", name: "ctn", config: config)
+        #expect(result?.networkAddress == "10.0.0.1")
+    }
+
+    @Test("decodeInspect multiple networks — first wins")
+    func decodeInspect_multipleNetworks_firstWins() {
+        let networks: [[String: Any]] = [
+            ["ipv4Address": "10.0.0.1/24"],
+            ["ipv4Address": "10.0.0.2/24"]
+        ]
+        let dict = makeDict(state: "running", ipv4Address: nil, networks: networks)
+        let config = makeConfig()
+        let result = ContainerEngine.decodeInspect(dict, id: "id1", name: "ctn", config: config)
+        #expect(result?.networkAddress == "10.0.0.1")
+    }
+
+    @Test("decodeInspect empty networks array returns empty address")
+    func decodeInspect_emptyNetworks_returnsEmptyAddress() {
+        let dict = makeDict(state: "running", ipv4Address: nil, networks: [])
+        let config = makeConfig()
+        let result = ContainerEngine.decodeInspect(dict, id: "id1", name: "ctn", config: config)
+        #expect(result?.networkAddress == "")
+    }
+
+    @Test("decodeInspect stopped container with network returns IP and exited state")
+    func decodeInspect_stoppedContainerWithNetwork_returnsIPAndExitedState() {
+        let dict = makeDict(state: "stopped", ipv4Address: "10.0.0.2/24")
+        let config = makeConfig()
+        let result = ContainerEngine.decodeInspect(dict, id: "id1", name: "ctn", config: config)
+        #expect(result?.state == .stopped)
+        #expect(result?.networkAddress == "10.0.0.2")
+    }
+
+    @Test("decodeInspect Compose regression — running container network address is non-empty")
+    func decodeInspect_networkAddress_nonEmptyForRunningContainer() {
+        let dict = makeDict(state: "running", ipv4Address: "172.16.0.5/16")
+        let config = makeConfig()
+        let result = ContainerEngine.decodeInspect(dict, id: "id1", name: "ctn", config: config)
+        // Covers the Compose /etc/hosts injection contract: networkAddress must be non-empty
+        // when the inspect blob carries a network, so injectServiceHostnames includes the container.
+        #expect(result?.networkAddress != "")
+        #expect(result?.networkAddress == "172.16.0.5")
+    }
+
+    // MARK: - Helper guard
+
+    @Test("decodeInspect missing configuration key returns nil")
+    func decodeInspect_missingConfigurationKey_returnsNil() {
+        let dict: [String: Any] = ["status": ["state": "running"] as [String: Any]]
+        let config = makeConfig()
+        let result = ContainerEngine.decodeInspect(dict, id: "id1", name: "ctn", config: config)
+        #expect(result == nil)
+    }
+}

--- a/Tests/MockerKitTests/ContainerEngineDecodeInspectTests.swift
+++ b/Tests/MockerKitTests/ContainerEngineDecodeInspectTests.swift
@@ -137,4 +137,14 @@ struct ContainerEngineDecodeInspectTests {
         let result = ContainerEngine.decodeInspect(dict, id: "id1", name: "ctn", config: config)
         #expect(result == nil)
     }
+
+    // MARK: - Display contract
+
+    @Test("ContainerState exited displayString matches expected constant")
+    func exitedDisplayString_matchesExpectedConstant() {
+        // Guards the runtime sync and stop paths that assign
+        // ContainerState.exited.displayString — if the constant ever drifts
+        // back to "Exited (0)" or similar, both paths regress.
+        #expect(ContainerState.exited.displayString == "Exited")
+    }
 }


### PR DESCRIPTION
## What problem does this solve?

`fetchContainerInfo` cast `status` to `String` (Apple emits it as an object)
and read networks at the top level (they live nested under `status.networks`).
Both casts silently failed, so every container reported as running with an
empty IP. This broke the `mocker ps` status column for stopped containers,
the `State` fields in `mocker container inspect`, and Compose `/etc/hosts`
injection (which silently no-ops because `networkAddress` is empty).

## What changed

- Extracted a pure static `ContainerEngine.decodeInspect` so the decode logic
  is unit-testable without a live container, and rewired `fetchContainerInfo`
  to call it. Returns `nil` to keep the existing outer fallback intact.
- Strip the `/24` mask from `status.networks[0].ipv4Address` so the IP we hand
  to `mocker ps`, the `inspect` DTO, and Compose hostname resolution is plain.
- Unknown Apple states fall back to `.running` (safe default — a live container
  is never hidden from `mocker ps`).
- Replaced three hardcoded `"Exited (0)"` strings with
  `ContainerState.exited.displayString` so the stopped display is honest
  ("Exited" — no fake exit code, per the maintainer's "omit > fake" policy).
