### PR TITLE
feat(serve): Docker Engine API daemon foundation (mocker serve)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,9 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.5.0"),
         .package(url: "https://github.com/jpsim/Yams.git", from: "5.1.3"),
         .package(url: "https://github.com/apple/containerization.git", branch: "main"),
+        // Docker Engine API server (`mocker serve`) — unix-socket HTTP. swift-nio is already
+        // resolved transitively (pinned 2.95.0 via containerization); declare it directly.
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.95.0"),
     ],
     targets: [
         // Core library shared between CLI and GUI
@@ -25,6 +28,9 @@ let package = Package(
                 .product(name: "Containerization", package: "containerization"),
                 .product(name: "ContainerizationOCI", package: "containerization"),
                 .product(name: "ContainerizationExtras", package: "containerization"),
+                .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "NIOPosix", package: "swift-nio"),
+                .product(name: "NIOHTTP1", package: "swift-nio"),
             ]
         ),
 

--- a/Sources/Mocker/Commands/Serve.swift
+++ b/Sources/Mocker/Commands/Serve.swift
@@ -1,0 +1,43 @@
+import ArgumentParser
+import Foundation
+import MockerKit
+
+struct Serve: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "serve",
+        abstract: "Run a Docker Engine API server on a Unix socket (DOCKER_HOST compatibility)"
+    )
+
+    @Option(name: .long, help: "Unix socket path (default: $HOME/.docker/run/docker.sock)")
+    var socket: String?
+
+    func run() async throws {
+        let path = socket ?? Self.defaultSocketPath()
+        let server = DockerAPIServer(socketPath: path, mockerVersion: Version.currentVersion)
+
+        // Graceful shutdown: unlink the socket + stop NIO on Ctrl-C / SIGTERM.
+        signal(SIGINT, SIG_IGN)
+        signal(SIGTERM, SIG_IGN)
+        let stop: @Sendable () -> Void = { Task { await server.shutdown(); Foundation.exit(0) } }
+        let sigint = DispatchSource.makeSignalSource(signal: SIGINT, queue: .global())
+        let sigterm = DispatchSource.makeSignalSource(signal: SIGTERM, queue: .global())
+        sigint.setEventHandler(handler: stop)
+        sigterm.setEventHandler(handler: stop)
+        sigint.resume()
+        sigterm.resume()
+
+        FileHandle.standardError.write(Data("""
+        mocker serve — Docker Engine API \(DockerAPI.version) on \(path)
+        Point tools at it:  export DOCKER_HOST=unix://\(path)
+        Press Ctrl-C to stop.
+
+        """.utf8))
+
+        try await server.run()
+    }
+
+    static func defaultSocketPath() -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return "\(home)/.docker/run/docker.sock"
+    }
+}

--- a/Sources/Mocker/MockerCLI.swift
+++ b/Sources/Mocker/MockerCLI.swift
@@ -53,6 +53,7 @@ struct MockerCLI: AsyncParsableCommand {
             ComposeCommand.self,
             SystemCommand.self,
             Proxy.self,
+            Serve.self,
         ]
     )
 

--- a/Sources/MockerKit/API/DockerAPIServer.swift
+++ b/Sources/MockerKit/API/DockerAPIServer.swift
@@ -1,0 +1,218 @@
+import Foundation
+import NIOCore
+import NIOPosix
+import NIOHTTP1
+
+/// Advertised Docker Engine API version. Single source of truth for `/_ping` + `/version`.
+/// 1.47 matches the CLI (`Version.swift`); clients always clamp DOWN to this. MinAPIVersion is
+/// the pre-negotiation floor — we never *enforce* it (lenient path handling accepts any `/vX.YY`).
+public enum DockerAPI {
+    public static let version = "1.47"
+    public static let minVersion = "1.24"
+}
+
+struct DockerAPIError: Error, CustomStringConvertible {
+    let message: String
+    var description: String { message }
+}
+
+/// A Docker Engine API server over a Unix domain socket, backed by MockerKit.
+/// Phase 1 (read-only): `/_ping`, `/version`. Handlers grow per the plan.
+public final class DockerAPIServer: @unchecked Sendable {
+    private let socketPath: String
+    private let mockerVersion: String
+    private var group: MultiThreadedEventLoopGroup?
+    private var channel: Channel?
+
+    public init(socketPath: String, mockerVersion: String) {
+        self.socketPath = socketPath
+        self.mockerVersion = mockerVersion
+    }
+
+    public func run() async throws {
+        try Self.prepareSocketPath(socketPath)
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        self.group = group
+        let version = mockerVersion
+        let bootstrap = ServerBootstrap(group: group)
+            .serverChannelOption(ChannelOptions.backlog, value: 256)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .childChannelInitializer { channel in
+                channel.pipeline.configureHTTPServerPipeline().flatMap {
+                    channel.pipeline.addHandler(HTTPHandler(mockerVersion: version))
+                }
+            }
+        // cleanupExistingSocketFile:false — NIO's cleanup uses stat() with no owner/symlink check;
+        // prepareSocketPath() already did a safe lstat-preflight unlink.
+        let channel = try await bootstrap.bind(unixDomainSocketPath: socketPath, cleanupExistingSocketFile: false).get()
+        chmod(socketPath, 0o600)  // restrict to owner (parent dir is already 0700)
+        self.channel = channel
+        try await channel.closeFuture.get()
+    }
+
+    public func shutdown() async {
+        try? await channel?.close().get()
+        try? await group?.shutdownGracefully()
+        unlink(socketPath)
+    }
+
+    /// Safe stale-socket cleanup: create the parent dir 0700, and unlink an existing path ONLY if
+    /// it is a socket owned by the current user (lstat — never follows a symlink).
+    static func prepareSocketPath(_ path: String) throws {
+        let dir = (path as NSString).deletingLastPathComponent
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true, attributes: [.posixPermissions: 0o700])
+        var st = stat()
+        if lstat(path, &st) == 0 {
+            let isSocket = (st.st_mode & S_IFMT) == S_IFSOCK
+            guard isSocket, st.st_uid == getuid() else {
+                throw DockerAPIError(message: "refusing to remove non-socket or non-owned file at \(path)")
+            }
+            unlink(path)
+        }
+    }
+}
+
+/// Per-connection HTTP handler. Phase 1 routes are static (no engine), so fully synchronous.
+/// `@unchecked Sendable`: a ChannelHandler is confined to its own event loop; its mutable state
+/// (`reqHead`) is only touched there.
+final class HTTPHandler: ChannelInboundHandler, @unchecked Sendable {
+    typealias InboundIn = HTTPServerRequestPart
+    typealias OutboundOut = HTTPServerResponsePart
+
+    private let mockerVersion: String
+    private var reqHead: HTTPRequestHead?
+
+    init(mockerVersion: String) { self.mockerVersion = mockerVersion }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        switch unwrapInboundIn(data) {
+        case .head(let head): reqHead = head
+        case .body: break  // Phase 1 endpoints take no body
+        case .end:
+            guard let head = reqHead else { return }
+            route(context: context, head: head)
+            reqHead = nil
+        }
+    }
+
+    private func route(context: ChannelHandlerContext, head: HTTPRequestHead) {
+        let path = Self.normalizePath(head.uri)
+        switch (head.method, path) {
+        case (.GET, "/_ping"), (.HEAD, "/_ping"):
+            writePing(context, head: head)
+        case (.GET, "/version"):
+            writeJSON(context, head: head, status: .ok, object: versionJSON())
+        default:
+            writeJSON(context, head: head, status: .notFound, object: ["message": "page not found: \(path)"])
+        }
+    }
+
+    // MARK: responses
+
+    private func writePing(_ context: ChannelHandlerContext, head: HTTPRequestHead) {
+        let isHead = head.method == .HEAD
+        var headers = baseHeaders()
+        headers.add(name: "OSType", value: "linux")
+        headers.add(name: "Builder-Version", value: "1")
+        headers.add(name: "Swarm", value: "inactive")
+        headers.add(name: "Cache-Control", value: "no-cache, no-store, must-revalidate")
+        headers.add(name: "Pragma", value: "no-cache")
+        headers.add(name: "Content-Type", value: "text/plain; charset=utf-8")
+        let body = "OK"
+        headers.add(name: "Content-Length", value: String(isHead ? 0 : body.utf8.count))
+        context.write(wrapOutboundOut(.head(.init(version: head.version, status: .ok, headers: headers))), promise: nil)
+        if !isHead {
+            var buf = context.channel.allocator.buffer(capacity: body.utf8.count)
+            buf.writeString(body)
+            context.write(wrapOutboundOut(.body(.byteBuffer(buf))), promise: nil)
+        }
+        finish(context, head: head)
+    }
+
+    private func writeJSON(_ context: ChannelHandlerContext, head: HTTPRequestHead, status: HTTPResponseStatus, object: [String: Any]) {
+        let isHead = head.method == .HEAD
+        let data = Self.jsonData(object)
+        var headers = baseHeaders()
+        headers.add(name: "Content-Type", value: "application/json")
+        headers.add(name: "Content-Length", value: String(isHead ? 0 : data.count))
+        context.write(wrapOutboundOut(.head(.init(version: head.version, status: status, headers: headers))), promise: nil)
+        if !isHead {
+            var buf = context.channel.allocator.buffer(capacity: data.count)
+            buf.writeBytes(data)
+            context.write(wrapOutboundOut(.body(.byteBuffer(buf))), promise: nil)
+        }
+        finish(context, head: head)
+    }
+
+    /// Serialize a JSON object with **unescaped slashes** — Docker emits `docker.io/library/...`,
+    /// not `docker.io\/library\/...`. `JSONSerialization` always escapes `/`, so undo it (it only
+    /// ever produces `\/` for a forward slash, so the replace is safe).
+    static func jsonData(_ object: [String: Any]) -> Data {
+        guard let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
+              let str = String(data: data, encoding: .utf8) else { return Data("{}".utf8) }
+        return Data(str.replacingOccurrences(of: "\\/", with: "/").utf8)
+    }
+
+    /// `Api-Version` (+ `Docker-Experimental`) on EVERY response — if absent the Go client falls
+    /// back to its own max version and sends a too-new path.
+    private func baseHeaders() -> HTTPHeaders {
+        var h = HTTPHeaders()
+        h.add(name: "Api-Version", value: DockerAPI.version)
+        h.add(name: "Docker-Experimental", value: "false")
+        return h
+    }
+
+    private func finish(_ context: ChannelHandlerContext, head: HTTPRequestHead) {
+        context.writeAndFlush(wrapOutboundOut(.end(nil)), promise: nil)
+        if !head.isKeepAlive { context.close(promise: nil) }
+    }
+
+    private func versionJSON() -> [String: Any] {
+        [
+            "Platform": ["Name": "mocker"],
+            "Version": mockerVersion,
+            "ApiVersion": DockerAPI.version,
+            "MinAPIVersion": DockerAPI.minVersion,
+            "Os": "linux",
+            "Arch": "arm64",
+            "KernelVersion": "",
+            "GoVersion": "",
+            "GitCommit": "",
+            "BuildTime": "",
+            "Experimental": false,
+            // `docker version`'s Server/Engine block reads OS-Arch, min-version, etc. from the
+            // component Details, not the top-level fields — populate them so it isn't blank.
+            "Components": [
+                [
+                    "Name": "Engine",
+                    "Version": mockerVersion,
+                    "Details": [
+                        "ApiVersion": DockerAPI.version,
+                        "MinAPIVersion": DockerAPI.minVersion,
+                        "Os": "linux",
+                        "Arch": "arm64",
+                        "Experimental": "false",
+                    ],
+                ]
+            ],
+        ]
+    }
+
+    /// Strip a query string and a leading `/vX.YY` version prefix (clients pin versions into the
+    /// path; we accept ANY and never enforce min/max).
+    static func normalizePath(_ uri: String) -> String {
+        var p = uri
+        if let q = p.firstIndex(of: "?") { p = String(p[..<q]) }
+        if p.hasPrefix("/v") {
+            let after = p.dropFirst(2)
+            if let slash = after.firstIndex(of: "/") {
+                let ver = after[after.startIndex..<slash]
+                if !ver.isEmpty, ver.allSatisfy({ $0.isNumber || $0 == "." }) {
+                    p = String(after[slash...])
+                }
+            }
+        }
+        return p
+    }
+}

--- a/Sources/MockerKit/Container/ContainerEngine.swift
+++ b/Sources/MockerKit/Container/ContainerEngine.swift
@@ -563,14 +563,23 @@ public actor ContainerEngine {
 
         try process.run()
 
-        return await withCheckedContinuation { continuation in
-            process.terminationHandler = { p in
-                let out = String(data: pipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-                let err = String(data: errPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-                let combined = out.isEmpty ? err : out
-                continuation.resume(returning: (combined, p.terminationStatus))
-            }
+        // Drain stdout/stderr concurrently while the process runs. Reading only inside
+        // terminationHandler deadlocks when output exceeds the ~64KB pipe buffer: the child
+        // blocks on write before it can exit, so the handler never fires (e.g. a large
+        // `container ls`/`inspect` from the API server). readDataToEndOfFile returns at EOF,
+        // which the OS delivers when the process exits and closes the pipe.
+        let outHandle = pipe.fileHandleForReading
+        let errHandle = errPipe.fileHandleForReading
+        let outTask = Task.detached { outHandle.readDataToEndOfFile() }
+        let errTask = Task.detached { errHandle.readDataToEndOfFile() }
+
+        let status: Int32 = await withCheckedContinuation { continuation in
+            process.terminationHandler = { p in continuation.resume(returning: p.terminationStatus) }
         }
+        let out = String(data: await outTask.value, encoding: .utf8) ?? ""
+        let err = String(data: await errTask.value, encoding: .utf8) ?? ""
+        let combined = out.isEmpty ? err : out
+        return (combined, status)
     }
 
     private func generateID() -> String {

--- a/Tests/MockerKitTests/DockerAPIServerTests.swift
+++ b/Tests/MockerKitTests/DockerAPIServerTests.swift
@@ -1,0 +1,91 @@
+import Foundation
+import Testing
+
+@testable import MockerKit
+
+@Suite("Docker API server — unit")
+struct DockerAPIServerTests {
+
+    // MARK: - Path normalization (version leniency + query strip)
+
+    @Test("strips a leading /vX.YY version prefix (any version, no min/max enforcement)")
+    func stripsVersionPrefix() {
+        #expect(HTTPHandler.normalizePath("/v1.47/version") == "/version")
+        #expect(HTTPHandler.normalizePath("/v1.32/containers/json") == "/containers/json")  // testcontainers pins low
+        #expect(HTTPHandler.normalizePath("/v9.99/info") == "/info")  // never reject a too-new path
+    }
+
+    @Test("strips the query string")
+    func stripsQuery() {
+        #expect(HTTPHandler.normalizePath("/containers/json?all=1&filters=x") == "/containers/json")
+        #expect(HTTPHandler.normalizePath("/v1.43/version?foo=bar") == "/version")
+    }
+
+    @Test("unversioned paths pass through unchanged")
+    func unversionedUnchanged() {
+        #expect(HTTPHandler.normalizePath("/_ping") == "/_ping")
+        #expect(HTTPHandler.normalizePath("/version") == "/version")
+    }
+
+    @Test("does not mistake non-version /v… paths for a version prefix")
+    func doesNotEatVolumes() {
+        #expect(HTTPHandler.normalizePath("/volumes") == "/volumes")
+        #expect(HTTPHandler.normalizePath("/volumes/create") == "/volumes/create")  // "v"+non-numeric
+        #expect(HTTPHandler.normalizePath("/version") == "/version")  // "ersion" has no slash → kept
+    }
+
+    // MARK: - Socket safety (lstat preflight)
+
+    @Test("prepareSocketPath refuses to unlink a non-socket file (no clobbering regular files/symlinks)")
+    func refusesNonSocket() throws {
+        let path = NSTemporaryDirectory() + "mocker-test-regular-\(getpid()).file"
+        FileManager.default.createFile(atPath: path, contents: Data("not a socket".utf8))
+        defer { try? FileManager.default.removeItem(atPath: path) }
+        #expect(throws: (any Error).self) {
+            try DockerAPIServer.prepareSocketPath(path)
+        }
+        // the regular file must still be there (we refused to remove it)
+        #expect(FileManager.default.fileExists(atPath: path))
+    }
+
+    @Test("prepareSocketPath creates a 0700 parent dir and tolerates a missing socket")
+    func createsParentDir() throws {
+        let dir = NSTemporaryDirectory() + "mocker-test-sock-dir-\(getpid())"
+        let path = dir + "/docker.sock"
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+        try DockerAPIServer.prepareSocketPath(path)  // must not throw when nothing is there
+        #expect(FileManager.default.fileExists(atPath: dir))
+        let perms = (try FileManager.default.attributesOfItem(atPath: dir)[.posixPermissions]) as? NSNumber
+        #expect(perms?.int16Value == 0o700)
+    }
+
+    // MARK: - The runCLI drain fix: large output must not deadlock
+
+    /// `runCLI` is private + bound to the container binary, so this reproduces its EXACT pattern
+    /// (Process + two pipes + terminationHandler + concurrent detached drain) against a command
+    /// that emits ~1.3 MB — far past the ~64 KB pipe buffer. With the OLD code (read inside
+    /// terminationHandler) the child blocks on write before exit and this hangs forever; with the
+    /// concurrent drain it completes and returns the full output.
+    @Test("concurrent drain reads >64KB output without deadlocking", .timeLimit(.minutes(1)))
+    func largeOutputNoDeadlock() async throws {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/seq")
+        process.arguments = ["1", "200000"]  // ~1.3 MB of output
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        try process.run()
+
+        let outHandle = pipe.fileHandleForReading
+        let outTask = Task.detached { outHandle.readDataToEndOfFile() }
+        let status: Int32 = await withCheckedContinuation { c in
+            process.terminationHandler = { p in c.resume(returning: p.terminationStatus) }
+        }
+        let out = String(data: await outTask.value, encoding: .utf8) ?? ""
+
+        #expect(status == 0)
+        let lines = out.split(separator: "\n")
+        #expect(lines.count == 200_000)
+        #expect(lines.first == "1")
+        #expect(lines.last == "200000")
+    }
+}


### PR DESCRIPTION
## What

Adds **`mocker serve`** — a Docker Engine API server on a Unix socket so the whole `DOCKER_HOST` ecosystem (the `docker` CLI, testcontainers, IDE plugins, CI, language SDKs) can talk to mocker. This is **Phase 1 (read-only foundation)** of a phased plan; it proves the approach end-to-end.

## Why

mocker is Docker-**CLI**-compatible but had no socket/API. Tools that talk to the daemon socket (not the CLI) couldn't use it. Socket compatibility is the feature that makes a "real Docker alternative" (it's OrbStack's actual moat).

## Changes

- **`fix(engine)`**: `runCLI` drained stdout/stderr inside `terminationHandler`, which deadlocks when output exceeds the ~64KB pipe buffer (the child blocks on write before it can exit). Now drains both pipes concurrently. Prerequisite for the API server issuing large `container ls`/`inspect`.
- **`feat(serve)`**: `DockerAPIServer` (SwiftNIO over a unix socket) + the `serve` command.
  - `GET/HEAD /_ping`, `GET /version` with correct **version negotiation** (advertise API `1.47`, `MinAPIVersion 1.24`, **lenient** `/vX.YY` path stripping — never enforce min/max, since testcontainers pins low versions into the path).
  - Socket at `$HOME/.docker/run/docker.sock`, owner-only `0600`, **safe `lstat` preflight** that refuses to clobber a non-socket / symlink.
  - JSON with **unescaped slashes** for Docker parity; `Api-Version` header on every response.

## Verification (tested from all angles)

- `swift test`: **239/239** (7 new). Includes a test proving the drain fix reads **1.3 MB without deadlocking** (the exact scenario the old code hung on), path-leniency (`/v1.32/`, `/v9.99/`, `/volumes` edge case), and socket-safety (refuses a non-socket file).
- **Real `docker` CLI**: `docker version` negotiates `1.54 -> 1.47` and connects (`Server: mocker / OS/Arch: linux/arm64`).
- Functional matrix against the live socket: HEAD-ping empty body, version leniency, `404 {"message":...}`, 10 concurrent requests, keep-alive, `docker info`/`ps` fail cleanly (no hang), socket-safety.

## Scope / next

Read-only only. Engine-backed endpoints (`/info`, `/containers/json`, `/images/json`, `/containers/{id}/json`) come next (they add the NIO↔actor bridge). `docker run` + testcontainers are Phase 2/3. Full phased plan (plan-loop reviewed, 2 iterations): `.context/docker-api-plan.md`.