### PR TITLE
fix!: make network inspect Docker-compatible

### DIFF
--- a/Sources/Mocker/Commands/Inspect.swift
+++ b/Sources/Mocker/Commands/Inspect.swift
@@ -4,6 +4,7 @@ import MockerKit
 enum InspectObjectType: String, ExpressibleByArgument {
     case image
     case container
+    case network
 }
 
 struct Inspect: AsyncParsableCommand {
@@ -30,6 +31,7 @@ struct Inspect: AsyncParsableCommand {
     enum Kind: Equatable {
         case image
         case container
+        case network
         case auto
     }
 
@@ -39,6 +41,7 @@ struct Inspect: AsyncParsableCommand {
         switch type {
         case .image: return .image
         case .container: return .container
+        case .network: return .network
         case nil: return .auto
         }
     }
@@ -61,6 +64,11 @@ struct Inspect: AsyncParsableCommand {
             let results = try await inspectContainers(targets: targets, engine: engine)
             try InspectFormat.emitArray(results, format: format)
 
+        case .network:
+            let networkManager = try NetworkManager(config: config)
+            let results = try await inspectNetworks(targets: targets, manager: networkManager)
+            try InspectFormat.emitArray(results, format: format)
+
         case .auto:
             for target in targets {
                 if let container = try? await engine.inspect(target) {
@@ -70,10 +78,15 @@ struct Inspect: AsyncParsableCommand {
                         let image = try await imageManager.inspect(target, platform: platform)
                         try InspectFormat.emitOne(image, format: format)
                     } catch {
-                        if platform != nil {
-                            throw error
+                        // 3rd attempt: network (--platform accepted for image targets only; ignored for network — Docker parity)
+                        let networkManager = try NetworkManager(config: config)
+                        do {
+                            let info = try await networkManager.inspect(target)
+                            try InspectFormat.emitOne(mapToNetworkInspect(info), format: format)
+                        } catch {
+                            if platform != nil { throw error }
+                            throw MockerError.networkNotFound(target)
                         }
-                        throw MockerError.containerNotFound(target)
                     }
                 }
             }

--- a/Sources/Mocker/Commands/Network.swift
+++ b/Sources/Mocker/Commands/Network.swift
@@ -171,23 +171,21 @@ struct NetworkRemove: AsyncParsableCommand {
 struct NetworkInspect: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "inspect",
-        abstract: "Display detailed information on a network"
+        abstract: "Display detailed information on one or more networks"
     )
 
     @Option(name: .shortAndLong, help: "Format output using the given Go template")
     var format: String?
 
-    @Flag(name: .shortAndLong, help: "Verbose output for diagnostics")
-    var verbose = false
-
-    @Argument(help: "Network name")
-    var name: String
+    @Argument(help: "Network name or ID")
+    var names: [String]
 
     func run() async throws {
         let config = MockerConfig()
+        try config.ensureDirectories()
         let manager = try NetworkManager(config: config)
-        let network = try await manager.inspect(name)
-        try TableFormatter.printJSON(network)
+        let results = try await inspectNetworks(targets: names, manager: manager)
+        try InspectFormat.emitArray(results, format: format)
     }
 }
 

--- a/Sources/MockerKit/Models/InspectOperations.swift
+++ b/Sources/MockerKit/Models/InspectOperations.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /// Inspects each target image and returns the per-target `ImageInspect` results.
 ///
 /// - Parameters:
@@ -35,6 +37,30 @@ public func inspectContainers(
             throw MockerError.containerNotFound(target)
         }
         results.append(mapToContainerInspect(container))
+    }
+    return results
+}
+
+/// Inspects each target network and returns Docker-compatible `NetworkInspect` results.
+/// Accumulates failures across all targets before throwing (Docker CLI parity).
+/// - Throws: `MockerError.networkNotFound` when any target cannot be resolved.
+public func inspectNetworks(
+    targets: [String],
+    manager: NetworkManager
+) async throws -> [NetworkInspect] {
+    var results: [NetworkInspect] = []
+    var firstFailed: String? = nil
+    for target in targets {
+        do {
+            let info = try await manager.inspect(target)  // await = actor hop, not I/O
+            results.append(mapToNetworkInspect(info))
+        } catch {
+            fputs("Error response from daemon: network \(target) not found\n", stderr)
+            if firstFailed == nil { firstFailed = target }
+        }
+    }
+    if let failed = firstFailed {
+        throw MockerError.networkNotFound(failed)
     }
     return results
 }

--- a/Sources/MockerKit/Models/NetworkInspect.swift
+++ b/Sources/MockerKit/Models/NetworkInspect.swift
@@ -1,0 +1,137 @@
+import Foundation
+
+/// Docker-compatible `network inspect` output (mirrors `docker network inspect`).
+/// Serializes with Docker PascalCase JSON keys per the moby v29.6.1 network.Inspect shape.
+/// Containers is always `{}` in v0.6.0 — Apple-runtime enrichment is deferred to a follow-up PR.
+public struct NetworkInspect: Encodable, Sendable {
+    enum CodingKeys: String, CodingKey {
+        case Name, Id, Created, Scope, Driver, EnableIPv4, EnableIPv6
+        case IPAM, Internal, Attachable, Ingress, ConfigFrom, ConfigOnly
+        case Containers, Options, Labels
+    }
+
+    public let Name: String
+    public let Id: String
+    public let Created: String
+    public let Scope: String
+    public let Driver: String
+    public let EnableIPv4: Bool
+    public let EnableIPv6: Bool
+    public let IPAM: NetworkIPAM
+    public let Internal: Bool
+    public let Attachable: Bool
+    public let Ingress: Bool
+    public let ConfigFrom: NetworkConfigReference
+    public let ConfigOnly: Bool
+    public var Containers: [String: NetworkEndpointResource]
+    public let Options: [String: String]
+    public let Labels: [String: String]
+
+    public init(
+        Name: String, Id: String, Created: String, Scope: String, Driver: String,
+        EnableIPv4: Bool, EnableIPv6: Bool, IPAM: NetworkIPAM,
+        Internal: Bool, Attachable: Bool, Ingress: Bool,
+        ConfigFrom: NetworkConfigReference, ConfigOnly: Bool,
+        Containers: [String: NetworkEndpointResource],
+        Options: [String: String], Labels: [String: String]
+    ) {
+        self.Name = Name; self.Id = Id; self.Created = Created
+        self.Scope = Scope; self.Driver = Driver
+        self.EnableIPv4 = EnableIPv4; self.EnableIPv6 = EnableIPv6
+        self.IPAM = IPAM; self.Internal = Internal
+        self.Attachable = Attachable; self.Ingress = Ingress
+        self.ConfigFrom = ConfigFrom; self.ConfigOnly = ConfigOnly
+        self.Containers = Containers; self.Options = Options; self.Labels = Labels
+    }
+}
+
+/// Docker-compatible IPAM sub-object. `Encodable` only — inspect output is write-only.
+/// Custom `encode(to:)` guarantees `"Options": null` when Options is nil (Docker parity).
+public struct NetworkIPAM: Encodable, Sendable {
+    enum CodingKeys: String, CodingKey { case Driver, Options, Config }
+
+    public let Driver: String
+    public let Options: [String: String]?
+    public let Config: [NetworkIPAMConfig]
+
+    public init(Driver: String, Options: [String: String]?, Config: [NetworkIPAMConfig]) {
+        self.Driver = Driver; self.Options = Options; self.Config = Config
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(Driver, forKey: .Driver)
+        if let opts = Options { try c.encode(opts, forKey: .Options) }
+        else { try c.encodeNil(forKey: .Options) }
+        try c.encode(Config, forKey: .Config)
+    }
+}
+
+/// One IPAM config entry. `IPRange` and `AuxiliaryAddresses` are omitted (moby omitempty).
+public struct NetworkIPAMConfig: Codable, Sendable {
+    enum CodingKeys: String, CodingKey { case Subnet, Gateway }
+
+    public let Subnet: String
+    public let Gateway: String?
+
+    public init(Subnet: String, Gateway: String? = nil) {
+        self.Subnet = Subnet; self.Gateway = Gateway
+    }
+}
+
+/// `ConfigFrom` sub-object. Always present with `Network: ""` when no config network is set.
+public struct NetworkConfigReference: Codable, Sendable {
+    enum CodingKeys: String, CodingKey { case Network }
+
+    public let Network: String
+
+    public init(Network: String = "") { self.Network = Network }
+}
+
+/// Endpoint resource entry in the `Containers` map.
+/// Defined now so the map type is stable for the Apple-runtime enrichment follow-up.
+public struct NetworkEndpointResource: Codable, Sendable, Equatable {
+    enum CodingKeys: String, CodingKey {
+        case Name, EndpointID, MacAddress, IPv4Address, IPv6Address
+    }
+
+    public let Name: String
+    public let EndpointID: String
+    public let MacAddress: String
+    public let IPv4Address: String
+    public let IPv6Address: String
+
+    public init(Name: String, EndpointID: String, MacAddress: String, IPv4Address: String, IPv6Address: String) {
+        self.Name = Name; self.EndpointID = EndpointID; self.MacAddress = MacAddress
+        self.IPv4Address = IPv4Address; self.IPv6Address = IPv6Address
+    }
+}
+
+/// Maps mocker's internal `NetworkInfo` to a Docker-compatible `NetworkInspect`. Pure, no I/O.
+public func mapToNetworkInspect(_ info: NetworkInfo) -> NetworkInspect {
+    let ipamConfig: [NetworkIPAMConfig]
+    if let subnet = info.subnet, !subnet.isEmpty {
+        ipamConfig = [NetworkIPAMConfig(
+            Subnet: subnet,
+            Gateway: info.gateway.flatMap { $0.isEmpty ? nil : $0 }
+        )]
+    } else {
+        ipamConfig = []
+    }
+    return NetworkInspect(
+        Name: info.name, Id: info.id,
+        Created: rfc3339String(info.created),
+        Scope: "local", Driver: info.driver,
+        EnableIPv4: true, EnableIPv6: false,
+        IPAM: NetworkIPAM(Driver: "default", Options: nil, Config: ipamConfig),
+        Internal: false, Attachable: false, Ingress: false,
+        ConfigFrom: NetworkConfigReference(), ConfigOnly: false,
+        Containers: [:], Options: [:], Labels: info.labels
+    )
+}
+
+private func rfc3339String(_ date: Date) -> String {
+    let formatter = ISO8601DateFormatter()
+    formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    return formatter.string(from: date)
+}

--- a/Tests/MockerKitTests/Fixtures/network-inspect/expected-bridge.json
+++ b/Tests/MockerKitTests/Fixtures/network-inspect/expected-bridge.json
@@ -1,0 +1,35 @@
+{
+  "Attachable" : false,
+  "ConfigFrom" : {
+    "Network" : ""
+  },
+  "ConfigOnly" : false,
+  "Containers" : {
+
+  },
+  "Created" : "2025-06-01T12:00:00.000Z",
+  "Driver" : "bridge",
+  "EnableIPv4" : true,
+  "EnableIPv6" : false,
+  "IPAM" : {
+    "Config" : [
+      {
+        "Gateway" : "192.168.64.1",
+        "Subnet" : "192.168.64.0\/24"
+      }
+    ],
+    "Driver" : "default",
+    "Options" : null
+  },
+  "Id" : "abc123def456789012345678901234567890abcd",
+  "Ingress" : false,
+  "Internal" : false,
+  "Labels" : {
+
+  },
+  "Name" : "bridge",
+  "Options" : {
+
+  },
+  "Scope" : "local"
+}

--- a/Tests/MockerKitTests/NetworkInspectMappingTests.swift
+++ b/Tests/MockerKitTests/NetworkInspectMappingTests.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Testing
+
+@testable import MockerKit
+
+@Suite("NetworkInspect Mapping Tests")
+struct NetworkInspectMappingTests {
+
+    private func sampleInfo() -> NetworkInfo {
+        NetworkInfo(
+            id: "abc123def456789012345678901234567890abcd",
+            name: "mynet",
+            driver: "bridge",
+            subnet: "192.168.64.0/24",
+            gateway: "192.168.64.1",
+            containers: [],
+            created: Date(timeIntervalSince1970: 1_748_779_200),
+            labels: ["env": "test"]
+        )
+    }
+
+    @Test("Top-level fields map from NetworkInfo")
+    func topLevelFields() {
+        let out = mapToNetworkInspect(sampleInfo())
+        #expect(out.Name == "mynet")
+        #expect(out.Id == "abc123def456789012345678901234567890abcd")
+        #expect(out.Driver == "bridge")
+        #expect(out.Scope == "local")
+        #expect(out.Created.hasPrefix("2025-06-01"))
+    }
+
+    @Test("Constant fields emit correct literals")
+    func constantFields() {
+        let out = mapToNetworkInspect(sampleInfo())
+        #expect(out.EnableIPv4 == true)
+        #expect(out.EnableIPv6 == false)
+        #expect(out.Internal == false)
+        #expect(out.Attachable == false)
+        #expect(out.Ingress == false)
+        #expect(out.ConfigOnly == false)
+    }
+
+    @Test("IPAM with subnet and gateway produces one Config entry")
+    func ipamWithSubnet() {
+        let out = mapToNetworkInspect(sampleInfo())
+        #expect(out.IPAM.Driver == "default")
+        #expect(out.IPAM.Options == nil)
+        #expect(out.IPAM.Config.count == 1)
+        #expect(out.IPAM.Config[0].Subnet == "192.168.64.0/24")
+        #expect(out.IPAM.Config[0].Gateway == "192.168.64.1")
+    }
+
+    @Test("IPAM with empty subnet produces empty Config array")
+    func ipamEmptySubnet() {
+        var info = sampleInfo()
+        info.subnet = nil; info.gateway = nil
+        let out = mapToNetworkInspect(info)
+        #expect(out.IPAM.Config.isEmpty)
+    }
+
+    @Test("Containers is always an empty map")
+    func containersAlwaysEmpty() {
+        var info = sampleInfo()
+        info.containers = ["web", "db"]
+        #expect(mapToNetworkInspect(info).Containers == [:])
+    }
+
+    @Test("Options is always an empty map")
+    func optionsAlwaysEmpty() {
+        #expect(mapToNetworkInspect(sampleInfo()).Options == [:])
+    }
+
+    @Test("Labels map directly from NetworkInfo")
+    func labelsDirectMapping() {
+        #expect(mapToNetworkInspect(sampleInfo()).Labels == ["env": "test"])
+    }
+
+    @Test("Labels are empty map when NetworkInfo has no labels")
+    func labelsEmptyWhenNone() {
+        var info = sampleInfo(); info.labels = [:]
+        #expect(mapToNetworkInspect(info).Labels == [:])
+    }
+
+    @Test("ConfigFrom always present with empty Network string")
+    func configFromAlwaysPresent() {
+        #expect(mapToNetworkInspect(sampleInfo()).ConfigFrom.Network == "")
+    }
+
+    @Test("Empty gateway string produces no Gateway key in IPAM Config")
+    func emptyGatewayOmitted() {
+        var info = sampleInfo(); info.gateway = ""
+        let out = mapToNetworkInspect(info)
+        #expect(out.IPAM.Config.count == 1)
+        #expect(out.IPAM.Config[0].Gateway == nil)
+    }
+
+    @Test("JSON shape: PascalCase keys, array wrap, Options null, Containers {}")
+    func jsonShape() throws {
+        let out = mapToNetworkInspect(sampleInfo())
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        let data = try encoder.encode([out])
+        let json = String(decoding: data, as: UTF8.self)
+        #expect(json.hasPrefix("["))
+        #expect(json.hasSuffix("]"))
+        #expect(json.contains("\"Name\""))
+        #expect(json.contains("\"IPAM\""))
+        #expect(json.contains("\"Containers\""))
+        #expect(json.contains("\"Options\" : null"))
+        #expect(json.contains("\"Containers\" : {"))
+        #expect(!json.contains("\\/"))
+        #expect(!json.contains("\"name\""))
+    }
+
+    @Test("Golden fixture: mapToNetworkInspect matches expected-bridge.json")
+    func goldenFixture() throws {
+        guard let url = Bundle.module.url(
+            forResource: "Fixtures/network-inspect/expected-bridge",
+            withExtension: "json"
+        ) else {
+            Issue.record("Fixture not found: expected-bridge.json"); return
+        }
+        let expected = try String(contentsOf: url, encoding: .utf8)
+        var info = sampleInfo(); info.name = "bridge"; info.labels = [:]
+        let data = try { () -> Data in
+            let e = JSONEncoder()
+            e.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+            return try e.encode(mapToNetworkInspect(info))
+        }()
+        func normalize(_ s: String) throws -> String {
+            let d = try JSONSerialization.data(withJSONObject: JSONSerialization.jsonObject(with: Data(s.utf8)), options: [.sortedKeys])
+            return String(decoding: d, as: UTF8.self)
+        }
+        #expect(try normalize(String(decoding: data, as: UTF8.self)) == normalize(expected))
+    }
+}

--- a/Tests/MockerTests/NetworkInspectCLITests.swift
+++ b/Tests/MockerTests/NetworkInspectCLITests.swift
@@ -43,4 +43,9 @@ struct NetworkInspectCLITests {
     func verboseFlagRemoved() throws {
         #expect(throws: Error.self) { _ = try NetworkInspect.parse(["--verbose", "mynet"]) }
     }
+
+    @Test("resolveKind maps .network to Kind.network")
+    func resolveKindNetwork() {
+        #expect(Inspect.resolveKind(type: .network) == .network)
+    }
 }

--- a/Tests/MockerTests/NetworkInspectCLITests.swift
+++ b/Tests/MockerTests/NetworkInspectCLITests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+import ArgumentParser
+import MockerKit
+@testable import Mocker
+
+@Suite("NetworkInspect CLI Tests")
+struct NetworkInspectCLITests {
+
+    @Test("network inspect unknown target throws networkNotFound")
+    func network_inspect_unknown_exits_one() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mocker-test-\(UUID().uuidString)").path
+        defer { try? FileManager.default.removeItem(atPath: tempDir) }
+        let config = MockerConfig(dataRoot: tempDir)
+        try config.ensureDirectories()
+        let manager = try NetworkManager(config: config)
+        await #expect(throws: MockerError.self) {
+            _ = try await inspectNetworks(targets: ["ghostnet"], manager: manager)
+        }
+    }
+
+    @Test("network inspect single target emits JSON array with PascalCase keys")
+    func network_inspect_single_emits_array() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mocker-test-\(UUID().uuidString)").path
+        defer { try? FileManager.default.removeItem(atPath: tempDir) }
+        let config = MockerConfig(dataRoot: tempDir)
+        try config.ensureDirectories()
+        let manager = try NetworkManager(config: config)
+        _ = try await manager.create(name: "testnet", driver: "bridge", subnet: "10.0.0.0/8", gateway: "10.0.0.1")
+        let results = try await inspectNetworks(targets: ["testnet"], manager: manager)
+        #expect(results.count == 1)
+        #expect(results[0].Name == "testnet")
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.withoutEscapingSlashes]
+        let json = String(decoding: try encoder.encode(results), as: UTF8.self)
+        #expect(json.hasPrefix("["))
+        #expect(json.contains("\"Name\""))
+    }
+
+    @Test("--verbose flag is rejected (removed from Docker-compatible interface)")
+    func verboseFlagRemoved() throws {
+        #expect(throws: Error.self) { _ = try NetworkInspect.parse(["--verbose", "mynet"]) }
+    }
+}


### PR DESCRIPTION
## What problem does this solve?

`mocker network inspect <name>` and `mocker inspect --type=network <name>` emit mocker's internal `NetworkInfo` shape — a single lowercase JSON object via `TableFormatter.printJSON`, not the Docker `network.Inspect` array of objects with PascalCase keys and nested IPAM. Scripts that pipe to `jq` and expect Docker fields (`.IPAM.Config[0].Subnet`, `.Containers`, top-level array) break.

`mocker inspect --type=network <name>` is also rejected at parse time today: the `InspectObjectType` enum only knows `image | container`, so the route is silently absent. Same for the auto-fallback path — `mocker inspect <name>` never tries network even when the target exists as a network.

This closes the last shipped command in the Docker-parity gap after #25 (image inspect) and #40 (container inspect).

## What changed

- New `NetworkInspect` DTO + pure `mapToNetworkInspect` mapper in `Sources/MockerKit/Models/NetworkInspect.swift`, mirroring the image- and container-inspect pattern. `NetworkIPAM` conforms to `Encodable` only with a custom `encode(to:)` that calls `encodeNil(forKey: .Options)` — Docker emits literal `"Options": null` for an unset IPAM driver-options map, not `{}`, and the default Swift `Codable` would have emitted `{}`.
- New `inspectNetworks` collector in `Sources/MockerKit/Models/InspectOperations.swift` with accumulate-then-fail multi-arg semantics: unknown targets emit `Error response from daemon: network <name> not found` to stderr, processing continues, exit 1 at the end. This intentionally diverges from `inspectContainers` (which throws on first miss) — copying that pattern would break multi-arg parity with `docker network inspect a b c`.
- `Sources/Mocker/Commands/Network.swift`: rewired `NetworkInspect` to variadic `names: [String]`, removed the `--verbose` flag (was a no-op), and migrated output from `TableFormatter.printJSON` to `InspectFormat.emitArray` so the subcommand emits a Docker-shaped JSON array with unescaped slashes and honors `--format` / `--format json` the same way image and container inspect already do.
- `Sources/Mocker/Commands/Inspect.swift`: extended `InspectObjectType` with `.network`, added the `.network` branch in `run()`, and added network as a third attempt in the auto-fallback loop after containers and images so `mocker inspect <name>` resolves to a network when neither matches.
- `Containers` map ships as `{}` empty for v0.6.0. Apple-runtime enrichment (real `EndpointID` / `MacAddress` / `IPv4Address` from `container network inspect <id>`) is intentionally deferred to a non-breaking follow-up so the breaking-shape change lands within the review budget. Fabricating Name-only stub entries was considered and rejected: Docker never emits entries with empty runtime-field strings, so doing so would invent a shape Docker would never produce.

## Breaking change

`mocker network inspect` no longer emits the lowercase `NetworkInfo` object. Scripts that read `.subnet`, `.gateway`, or `.containers` from a top-level object must migrate to `.IPAM.Config[0].Subnet`, `.IPAM.Config[0].Gateway`, and `.Containers` (a map, empty `{}` in v0.6.0 until the enrichment follow-up). The top-level is now a JSON array, so `jq` filters need `.[0].Name` instead of `.name`. `mocker inspect --type=network <id>` is a new route — it did not exist before — so nothing breaks there. Multi-arg `network inspect a b c` now returns one combined array (previously rejected: single-arg only).
