### PR TITLE
fix(compose): resolve relative volume paths to absolute before mounting

### DIFF
--- a/Sources/MockerKit/Compose/ComposeOrchestrator.swift
+++ b/Sources/MockerKit/Compose/ComposeOrchestrator.swift
@@ -239,19 +239,7 @@ public actor ComposeOrchestrator {
         // Parse port mappings
         let ports = try service.ports.map { try PortMapping.parse($0) }
 
-        // Parse volumes — bind-mount absolute/relative host paths only.
-        // Named volumes (no leading '/') are skipped: Apple's virtiofs mounts don't
-        // support chown from within containers, which breaks images like postgres that
-        // chown their data directory on init. Containers use internal VM storage instead.
-        var volumes: [VolumeMount] = []
-        for volSpec in service.volumes {
-            let mount = try VolumeMount.parse(volSpec)
-            // Only bind-mount absolute host paths; skip named volumes
-            if mount.source.isEmpty || mount.source.hasPrefix("/") {
-                volumes.append(mount)
-            }
-            // Named volumes are intentionally skipped — container uses internal storage
-        }
+        let volumes = try Self.resolveVolumeMounts(service.volumes)
 
         let config = ContainerConfig(
             name: containerName,
@@ -270,5 +258,34 @@ public actor ComposeOrchestrator {
         )
 
         return try await engine.run(config)
+    }
+
+    /// Resolve volume spec strings from a compose service into `VolumeMount` values.
+    ///
+    /// Bind-mount host paths (absolute or relative) are included; anonymous volumes
+    /// (container paths only) are included; named volumes (bare names without path
+    /// separators) are skipped — Apple's virtiofs doesn't support chown from within
+    /// containers, which breaks images like postgres that chown their data directory
+    /// on init.
+    ///
+    /// Relative paths (`./foo`, `../bar`, `data/dir`) are resolved to absolute paths
+    /// against the current working directory. This matches Docker Compose behaviour
+    /// because `mocker compose` is run from the project directory.
+    static func resolveVolumeMounts(_ volSpecs: [String]) throws -> [VolumeMount] {
+        var volumes: [VolumeMount] = []
+        for volSpec in volSpecs {
+            var mount = try VolumeMount.parse(volSpec)
+            if mount.source.isEmpty {
+                volumes.append(mount)
+            } else if mount.source.hasPrefix("/") {
+                volumes.append(mount)
+            } else if mount.source.hasPrefix(".")
+                      || mount.source.hasPrefix("~")
+                      || mount.source.contains("/") {
+                mount.source = URL(fileURLWithPath: mount.source).path
+                volumes.append(mount)
+            }
+        }
+        return volumes
     }
 }

--- a/Tests/MockerKitTests/ComposeOrchestratorTests.swift
+++ b/Tests/MockerKitTests/ComposeOrchestratorTests.swift
@@ -149,4 +149,90 @@ struct ComposeOrchestratorTests {
         #expect(!ComposeService.imageMatches(img, tag: "proj-app:v2"))
         #expect(!ComposeService.imageMatches(img, tag: "other-app:latest"))
     }
+
+    // MARK: - Volume mount resolution (issue #49)
+
+    @Test("Absolute bind mount included as-is")
+    func resolveAbsoluteBindMount() throws {
+        let mounts = try ComposeOrchestrator.resolveVolumeMounts(["/host/data:/container/data"])
+        #expect(mounts.count == 1)
+        #expect(mounts[0].source == "/host/data")
+        #expect(mounts[0].destination == "/container/data")
+    }
+
+    @Test("Relative bind mount resolved to absolute path")
+    func resolveRelativeBindMount() throws {
+        let mounts = try ComposeOrchestrator.resolveVolumeMounts(["./foo:/bar"])
+        #expect(mounts.count == 1)
+        #expect(mounts[0].source.hasPrefix("/"))
+        #expect(mounts[0].source.hasSuffix("/foo"))
+        #expect(mounts[0].destination == "/bar")
+    }
+
+    @Test("Parent-relative bind mount resolved to absolute path")
+    func resolveParentRelativeBindMount() throws {
+        let mounts = try ComposeOrchestrator.resolveVolumeMounts(["../data:/container/data"])
+        #expect(mounts.count == 1)
+        #expect(mounts[0].source.hasPrefix("/"))
+        #expect(mounts[0].source.hasSuffix("/data"))
+        #expect(mounts[0].destination == "/container/data")
+    }
+
+    @Test("Path with directory separator but no leading dot resolved")
+    func resolveDirSeparatorPath() throws {
+        let mounts = try ComposeOrchestrator.resolveVolumeMounts(["mydir/data:/container/data"])
+        #expect(mounts.count == 1)
+        #expect(mounts[0].source.hasPrefix("/"))
+        #expect(mounts[0].source.hasSuffix("mydir/data"))
+        #expect(mounts[0].destination == "/container/data")
+    }
+
+    @Test("Named volume skipped")
+    func skipNamedVolume() throws {
+        let mounts = try ComposeOrchestrator.resolveVolumeMounts(["mydata:/container/data"])
+        #expect(mounts.isEmpty)
+    }
+
+    @Test("Anonymous volume included")
+    func includeAnonymousVolume() throws {
+        let mounts = try ComposeOrchestrator.resolveVolumeMounts(["/container/data"])
+        #expect(mounts.count == 1)
+        #expect(mounts[0].source == "")
+        #expect(mounts[0].destination == "/container/data")
+    }
+
+    @Test("Mix of bind mounts, named volumes, and anonymous volumes")
+    func resolveMixedVolumes() throws {
+        let mounts = try ComposeOrchestrator.resolveVolumeMounts([
+            "/abs/path:/app/data",
+            "./relative:/app/rel",
+            "namedvol:/app/named",
+            "/app/anon",
+            "sub/dir:/app/sub",
+        ])
+        #expect(mounts.count == 4)  // namedvol skipped
+        let sources = mounts.map(\.source)
+        #expect(sources.contains("/abs/path"))
+        #expect(sources.contains(""))  // anonymous
+        #expect(sources.contains(where: { $0.hasSuffix("/relative") }))
+        #expect(sources.contains(where: { $0.hasSuffix("sub/dir") }))
+    }
+
+    @Test("Read-only relative bind mount preserves ro flag")
+    func resolveRelativeReadOnly() throws {
+        let mounts = try ComposeOrchestrator.resolveVolumeMounts(["./data:/container/data:ro"])
+        #expect(mounts.count == 1)
+        #expect(mounts[0].readOnly == true)
+        #expect(mounts[0].destination == "/container/data")
+        #expect(mounts[0].source.hasSuffix("/data"))
+    }
+
+    @Test("Home-relative path resolved")
+    func resolveHomeRelativePath() throws {
+        let mounts = try ComposeOrchestrator.resolveVolumeMounts(["~/data:/container/data"])
+        #expect(mounts.count == 1)
+        #expect(mounts[0].source.hasPrefix("/"))
+        #expect(mounts[0].source.contains("data"))
+        #expect(mounts[0].destination == "/container/data")
+    }
 }

--- a/Tests/MockerKitTests/ComposeOrchestratorTests.swift
+++ b/Tests/MockerKitTests/ComposeOrchestratorTests.swift
@@ -160,31 +160,20 @@ struct ComposeOrchestratorTests {
         #expect(mounts[0].destination == "/container/data")
     }
 
-    @Test("Relative bind mount resolved to absolute path")
-    func resolveRelativeBindMount() throws {
-        let mounts = try ComposeOrchestrator.resolveVolumeMounts(["./foo:/bar"])
+    @Test(
+        "Relative-style sources resolved to absolute path",
+        arguments: [
+            ("./foo:/bar", "/foo", "/bar"),
+            ("../data:/container/data", "/data", "/container/data"),
+            ("mydir/data:/container/data", "mydir/data", "/container/data"),
+        ]
+    )
+    func resolveRelativeStyleMounts(spec: String, suffix: String, destination: String) throws {
+        let mounts = try ComposeOrchestrator.resolveVolumeMounts([spec])
         #expect(mounts.count == 1)
         #expect(mounts[0].source.hasPrefix("/"))
-        #expect(mounts[0].source.hasSuffix("/foo"))
-        #expect(mounts[0].destination == "/bar")
-    }
-
-    @Test("Parent-relative bind mount resolved to absolute path")
-    func resolveParentRelativeBindMount() throws {
-        let mounts = try ComposeOrchestrator.resolveVolumeMounts(["../data:/container/data"])
-        #expect(mounts.count == 1)
-        #expect(mounts[0].source.hasPrefix("/"))
-        #expect(mounts[0].source.hasSuffix("/data"))
-        #expect(mounts[0].destination == "/container/data")
-    }
-
-    @Test("Path with directory separator but no leading dot resolved")
-    func resolveDirSeparatorPath() throws {
-        let mounts = try ComposeOrchestrator.resolveVolumeMounts(["mydir/data:/container/data"])
-        #expect(mounts.count == 1)
-        #expect(mounts[0].source.hasPrefix("/"))
-        #expect(mounts[0].source.hasSuffix("mydir/data"))
-        #expect(mounts[0].destination == "/container/data")
+        #expect(mounts[0].source.hasSuffix(suffix))
+        #expect(mounts[0].destination == destination)
     }
 
     @Test("Named volume skipped")


### PR DESCRIPTION
Relative volume paths (`./foo`, `../bar`, `data/dir`) in compose services were silently dropped because the volume filter only accepted sources starting with `/`.

**What changed:**
- Extracted volume resolution into `ComposeOrchestrator.resolveVolumeMounts()` so it's testable
- Relative paths are now resolved to absolute via `URL(fileURLWithPath:)` — matches Docker Compose's resolve-against-project-directory behavior
- Named volumes (bare names, no path separators) remain skipped as before
- Anonymous volumes (container-only paths) remain included

**Tests:** 9 new unit tests covering absolute, relative (`./`, `../`), directory-separator paths, named volume skip, anonymous volume, mixed scenarios, read-only flag preservation, and home-relative paths.

Fixes #49

💘 Generated with Crush