### PR TITLE
fix(compose)!: honor Docker's project-directory anchoring model

### DIFF
--- a/Sources/Mocker/Commands/Compose.swift
+++ b/Sources/Mocker/Commands/Compose.swift
@@ -213,7 +213,7 @@ struct ComposeUp: AsyncParsableCommand {
     var services: [String] = []
 
     func run() async throws {
-        var (composeFile, project, _) = try options.loadCompose()
+        var (composeFile, project, projectDir) = try options.loadCompose()
         let config = MockerConfig()
         try config.ensureDirectories()
 
@@ -229,6 +229,7 @@ struct ComposeUp: AsyncParsableCommand {
 
         let orchestrator = ComposeOrchestrator(
             projectName: project,
+            projectDir: projectDir,
             engine: engine,
             imageManager: imageManager,
             networkManager: networkManager,
@@ -265,7 +266,7 @@ struct ComposeDown: AsyncParsableCommand {
     var rmi: String?
 
     func run() async throws {
-        let (composeFile, project, _) = try options.loadCompose()
+        let (composeFile, project, projectDir) = try options.loadCompose()
         let config = MockerConfig()
 
         let engine = try ContainerEngine(config: config)
@@ -275,6 +276,7 @@ struct ComposeDown: AsyncParsableCommand {
 
         let orchestrator = ComposeOrchestrator(
             projectName: project,
+            projectDir: projectDir,
             engine: engine,
             imageManager: imageManager,
             networkManager: networkManager,
@@ -326,7 +328,7 @@ struct ComposePS: AsyncParsableCommand {
     var services: [String] = []
 
     func run() async throws {
-        let (_, project, _) = try options.loadCompose()
+        let (_, project, projectDir) = try options.loadCompose()
         let config = MockerConfig()
 
         let engine = try ContainerEngine(config: config)
@@ -336,6 +338,7 @@ struct ComposePS: AsyncParsableCommand {
 
         let orchestrator = ComposeOrchestrator(
             projectName: project,
+            projectDir: projectDir,
             engine: engine,
             imageManager: imageManager,
             networkManager: networkManager,
@@ -420,7 +423,7 @@ struct ComposeLogs: AsyncParsableCommand {
     var until: String?
 
     func run() async throws {
-        let (_, project, _) = try options.loadCompose()
+        let (_, project, projectDir) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
         let imageManager = try ImageManager(config: config)
@@ -429,6 +432,7 @@ struct ComposeLogs: AsyncParsableCommand {
 
         let orchestrator = ComposeOrchestrator(
             projectName: project,
+            projectDir: projectDir,
             engine: engine,
             imageManager: imageManager,
             networkManager: networkManager,
@@ -473,7 +477,7 @@ struct ComposeKill: AsyncParsableCommand {
     var signal: String?
 
     func run() async throws {
-        let (_, project, _) = try options.loadCompose()
+        let (_, project, projectDir) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
         let imageManager = try ImageManager(config: config)
@@ -482,6 +486,7 @@ struct ComposeKill: AsyncParsableCommand {
 
         let orchestrator = ComposeOrchestrator(
             projectName: project,
+            projectDir: projectDir,
             engine: engine,
             imageManager: imageManager,
             networkManager: networkManager,
@@ -518,7 +523,7 @@ struct ComposeRestart: AsyncParsableCommand {
     var timeout: Int?
 
     func run() async throws {
-        let (composeFile, project, _) = try options.loadCompose()
+        let (composeFile, project, projectDir) = try options.loadCompose()
         let config = MockerConfig()
 
         let engine = try ContainerEngine(config: config)
@@ -528,6 +533,7 @@ struct ComposeRestart: AsyncParsableCommand {
 
         let orchestrator = ComposeOrchestrator(
             projectName: project,
+            projectDir: projectDir,
             engine: engine,
             imageManager: imageManager,
             networkManager: networkManager,
@@ -595,7 +601,7 @@ struct ComposeBuildCommand: AsyncParsableCommand {
     var services: [String] = []
 
     func run() async throws {
-        let (composeFile, _, _) = try options.loadCompose()
+        let (composeFile, _, projectDir) = try options.loadCompose()
         let config = MockerConfig()
         let manager = try ImageManager(config: config)
 
@@ -607,13 +613,14 @@ struct ComposeBuildCommand: AsyncParsableCommand {
             guard let buildConfig = service.build else { continue }
             let tag = service.image ?? "\(name):latest"
             if !quiet { print("Building \(name)...") }
+            let absContext = ImageManager.resolveContextPath(context: buildConfig.context, cwd: projectDir.path)
             let dockerfilePath = ImageManager.composeDockerfilePath(
-                context: buildConfig.context,
+                context: absContext,
                 dockerfile: buildConfig.dockerfile ?? "Dockerfile",
-                cwd: FileManager.default.currentDirectoryPath
+                cwd: projectDir.path
             )
             _ = try await manager.build(
-                tag: tag, context: buildConfig.context,
+                tag: tag, context: absContext,
                 dockerfile: dockerfilePath,
                 noCache: noCache, buildArgs: buildConfig.argList + buildArg,
                 target: buildConfig.target
@@ -960,7 +967,7 @@ struct ComposeStop: AsyncParsableCommand {
     var services: [String] = []
 
     func run() async throws {
-        let (_, project, _) = try options.loadCompose()
+        let (_, project, projectDir) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
         let imageManager = try ImageManager(config: config)
@@ -969,6 +976,7 @@ struct ComposeStop: AsyncParsableCommand {
 
         let orchestrator = ComposeOrchestrator(
             projectName: project,
+            projectDir: projectDir,
             engine: engine,
             imageManager: imageManager,
             networkManager: networkManager,
@@ -1010,7 +1018,7 @@ struct ComposeStart: AsyncParsableCommand {
     var services: [String] = []
 
     func run() async throws {
-        let (_, project, _) = try options.loadCompose()
+        let (_, project, projectDir) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
         let imageManager = try ImageManager(config: config)
@@ -1019,6 +1027,7 @@ struct ComposeStart: AsyncParsableCommand {
 
         let orchestrator = ComposeOrchestrator(
             projectName: project,
+            projectDir: projectDir,
             engine: engine,
             imageManager: imageManager,
             networkManager: networkManager,
@@ -1063,7 +1072,7 @@ struct ComposeRm: AsyncParsableCommand {
     var services: [String] = []
 
     func run() async throws {
-        let (_, project, _) = try options.loadCompose()
+        let (_, project, projectDir) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
         let imageManager = try ImageManager(config: config)
@@ -1072,6 +1081,7 @@ struct ComposeRm: AsyncParsableCommand {
 
         let orchestrator = ComposeOrchestrator(
             projectName: project,
+            projectDir: projectDir,
             engine: engine,
             imageManager: imageManager,
             networkManager: networkManager,
@@ -1238,7 +1248,7 @@ struct ComposeCreate: AsyncParsableCommand {
 
     func run() async throws {
         // create is essentially up without starting — for now delegate to up
-        var (composeFile, project, _) = try options.loadCompose()
+        var (composeFile, project, projectDir) = try options.loadCompose()
         let config = MockerConfig()
         try config.ensureDirectories()
 
@@ -1253,6 +1263,7 @@ struct ComposeCreate: AsyncParsableCommand {
 
         let orchestrator = ComposeOrchestrator(
             projectName: project,
+            projectDir: projectDir,
             engine: engine,
             imageManager: imageManager,
             networkManager: networkManager,
@@ -1284,7 +1295,7 @@ struct ComposeImages: AsyncParsableCommand {
     var quiet = false
 
     func run() async throws {
-        let (_, project, _) = try options.loadCompose()
+        let (_, project, projectDir) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
         let imageManager = try ImageManager(config: config)
@@ -1293,6 +1304,7 @@ struct ComposeImages: AsyncParsableCommand {
 
         let orchestrator = ComposeOrchestrator(
             projectName: project,
+            projectDir: projectDir,
             engine: engine,
             imageManager: imageManager,
             networkManager: networkManager,
@@ -1328,7 +1340,7 @@ struct ComposeTop: AsyncParsableCommand {
     var services: [String] = []
 
     func run() async throws {
-        let (_, project, _) = try options.loadCompose()
+        let (_, project, projectDir) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
         let imageManager = try ImageManager(config: config)
@@ -1337,6 +1349,7 @@ struct ComposeTop: AsyncParsableCommand {
 
         let orchestrator = ComposeOrchestrator(
             projectName: project,
+            projectDir: projectDir,
             engine: engine,
             imageManager: imageManager,
             networkManager: networkManager,
@@ -1415,7 +1428,7 @@ struct ComposePause: AsyncParsableCommand {
     var services: [String] = []
 
     func run() async throws {
-        let (_, project, _) = try options.loadCompose()
+        let (_, project, projectDir) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
         let imageManager = try ImageManager(config: config)
@@ -1424,6 +1437,7 @@ struct ComposePause: AsyncParsableCommand {
 
         let orchestrator = ComposeOrchestrator(
             projectName: project,
+            projectDir: projectDir,
             engine: engine,
             imageManager: imageManager,
             networkManager: networkManager,
@@ -1457,7 +1471,7 @@ struct ComposeUnpause: AsyncParsableCommand {
     var services: [String] = []
 
     func run() async throws {
-        let (_, project, _) = try options.loadCompose()
+        let (_, project, projectDir) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
         let imageManager = try ImageManager(config: config)
@@ -1466,6 +1480,7 @@ struct ComposeUnpause: AsyncParsableCommand {
 
         let orchestrator = ComposeOrchestrator(
             projectName: project,
+            projectDir: projectDir,
             engine: engine,
             imageManager: imageManager,
             networkManager: networkManager,

--- a/Sources/Mocker/Commands/Compose.swift
+++ b/Sources/Mocker/Commands/Compose.swift
@@ -56,10 +56,18 @@ struct ComposeOptions: ParsableArguments {
     @Option(name: [.customShort("p"), .customLong("project-name")], help: "Project name")
     var projectName: String?
 
-    func loadCompose() throws -> (ComposeFile, String) {
+    @Option(name: .customLong("project-directory"), help: "Specify an alternate working directory")
+    var projectDirectory: String?
+
+    func loadCompose() throws -> (ComposeFile, projectName: String, projectDir: URL) {
+        let cwd = FileManager.default.currentDirectoryPath
+        let projectDir = ComposeFile.resolveProjectDirectory(
+            explicit: projectDirectory, files: files, cwd: cwd
+        )
+
         let paths: [String]
         if files.isEmpty {
-            guard let def = ComposeFile.findDefault() else {
+            guard let def = ComposeFile.findDefault(in: projectDir.path) else {
                 let searched = ComposeFile.defaultFileNames.joined(separator: ", ")
                 throw MockerError.composeFileNotFound("No compose file found. Searched for: \(searched)")
             }
@@ -68,17 +76,12 @@ struct ComposeOptions: ParsableArguments {
             paths = files
         }
 
-        let loaded = try paths.map { try ComposeFile.load(from: $0) }
+        let loaded = try paths.map { try ComposeFile.load(from: $0, projectDir: projectDir) }
         let composeFile = ComposeFile.merge(loaded)
 
-        // Derive project name from the first file's directory if not specified.
-        let project = projectName ?? URL(fileURLWithPath: paths[0])
-            .deletingLastPathComponent()
-            .lastPathComponent
-            .lowercased()
-            .replacingOccurrences(of: " ", with: "-")
+        let project = projectName ?? ComposeFile.normalizeProjectName(projectDir.lastPathComponent)
 
-        return (composeFile, project)
+        return (composeFile, project, projectDir)
     }
 }
 
@@ -210,7 +213,7 @@ struct ComposeUp: AsyncParsableCommand {
     var services: [String] = []
 
     func run() async throws {
-        var (composeFile, project) = try options.loadCompose()
+        var (composeFile, project, _) = try options.loadCompose()
         let config = MockerConfig()
         try config.ensureDirectories()
 
@@ -262,7 +265,7 @@ struct ComposeDown: AsyncParsableCommand {
     var rmi: String?
 
     func run() async throws {
-        let (composeFile, project) = try options.loadCompose()
+        let (composeFile, project, _) = try options.loadCompose()
         let config = MockerConfig()
 
         let engine = try ContainerEngine(config: config)
@@ -323,7 +326,7 @@ struct ComposePS: AsyncParsableCommand {
     var services: [String] = []
 
     func run() async throws {
-        let (_, project) = try options.loadCompose()
+        let (_, project, _) = try options.loadCompose()
         let config = MockerConfig()
 
         let engine = try ContainerEngine(config: config)
@@ -417,7 +420,7 @@ struct ComposeLogs: AsyncParsableCommand {
     var until: String?
 
     func run() async throws {
-        let (_, project) = try options.loadCompose()
+        let (_, project, _) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
         let imageManager = try ImageManager(config: config)
@@ -470,7 +473,7 @@ struct ComposeKill: AsyncParsableCommand {
     var signal: String?
 
     func run() async throws {
-        let (_, project) = try options.loadCompose()
+        let (_, project, _) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
         let imageManager = try ImageManager(config: config)
@@ -515,7 +518,7 @@ struct ComposeRestart: AsyncParsableCommand {
     var timeout: Int?
 
     func run() async throws {
-        let (composeFile, project) = try options.loadCompose()
+        let (composeFile, project, _) = try options.loadCompose()
         let config = MockerConfig()
 
         let engine = try ContainerEngine(config: config)
@@ -592,7 +595,7 @@ struct ComposeBuildCommand: AsyncParsableCommand {
     var services: [String] = []
 
     func run() async throws {
-        let (composeFile, _) = try options.loadCompose()
+        let (composeFile, _, _) = try options.loadCompose()
         let config = MockerConfig()
         let manager = try ImageManager(config: config)
 
@@ -652,7 +655,7 @@ struct ComposePull: AsyncParsableCommand {
     var services: [String] = []
 
     func run() async throws {
-        let (composeFile, _) = try options.loadCompose()
+        let (composeFile, _, _) = try options.loadCompose()
         let config = MockerConfig()
         let manager = try ImageManager(config: config)
 
@@ -703,7 +706,7 @@ struct ComposePush: AsyncParsableCommand {
     var services: [String] = []
 
     func run() async throws {
-        let (composeFile, _) = try options.loadCompose()
+        let (composeFile, _, _) = try options.loadCompose()
         let config = MockerConfig()
         let manager = try ImageManager(config: config)
 
@@ -782,7 +785,7 @@ struct ComposeExec: AsyncParsableCommand {
     }
 
     func run() async throws {
-        let (_, project) = try options.loadCompose()
+        let (_, project, _) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
 
@@ -896,7 +899,7 @@ struct ComposeRun: AsyncParsableCommand {
     }
 
     func run() async throws {
-        let (composeFile, _) = try options.loadCompose()
+        let (composeFile, _, _) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
 
@@ -957,7 +960,7 @@ struct ComposeStop: AsyncParsableCommand {
     var services: [String] = []
 
     func run() async throws {
-        let (_, project) = try options.loadCompose()
+        let (_, project, _) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
         let imageManager = try ImageManager(config: config)
@@ -1007,7 +1010,7 @@ struct ComposeStart: AsyncParsableCommand {
     var services: [String] = []
 
     func run() async throws {
-        let (_, project) = try options.loadCompose()
+        let (_, project, _) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
         let imageManager = try ImageManager(config: config)
@@ -1060,7 +1063,7 @@ struct ComposeRm: AsyncParsableCommand {
     var services: [String] = []
 
     func run() async throws {
-        let (_, project) = try options.loadCompose()
+        let (_, project, _) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
         let imageManager = try ImageManager(config: config)
@@ -1159,7 +1162,7 @@ struct ComposeConfig: AsyncParsableCommand {
     var variables = false
 
     func run() async throws {
-        let (composeFile, _) = try options.loadCompose()
+        let (composeFile, _, _) = try options.loadCompose()
 
         if quiet { return }
 
@@ -1235,7 +1238,7 @@ struct ComposeCreate: AsyncParsableCommand {
 
     func run() async throws {
         // create is essentially up without starting — for now delegate to up
-        var (composeFile, project) = try options.loadCompose()
+        var (composeFile, project, _) = try options.loadCompose()
         let config = MockerConfig()
         try config.ensureDirectories()
 
@@ -1281,7 +1284,7 @@ struct ComposeImages: AsyncParsableCommand {
     var quiet = false
 
     func run() async throws {
-        let (_, project) = try options.loadCompose()
+        let (_, project, _) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
         let imageManager = try ImageManager(config: config)
@@ -1325,7 +1328,7 @@ struct ComposeTop: AsyncParsableCommand {
     var services: [String] = []
 
     func run() async throws {
-        let (_, project) = try options.loadCompose()
+        let (_, project, _) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
         let imageManager = try ImageManager(config: config)
@@ -1383,7 +1386,7 @@ struct ComposePort: AsyncParsableCommand {
     var `protocol`: String?
 
     func run() async throws {
-        let (_, project) = try options.loadCompose()
+        let (_, project, _) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
 
@@ -1412,7 +1415,7 @@ struct ComposePause: AsyncParsableCommand {
     var services: [String] = []
 
     func run() async throws {
-        let (_, project) = try options.loadCompose()
+        let (_, project, _) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
         let imageManager = try ImageManager(config: config)
@@ -1454,7 +1457,7 @@ struct ComposeUnpause: AsyncParsableCommand {
     var services: [String] = []
 
     func run() async throws {
-        let (_, project) = try options.loadCompose()
+        let (_, project, _) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
         let imageManager = try ImageManager(config: config)
@@ -1563,7 +1566,7 @@ struct ComposeCp: AsyncParsableCommand {
     var followLink = false
 
     func run() async throws {
-        let (_, project) = try options.loadCompose()
+        let (_, project, _) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
 
@@ -1644,7 +1647,7 @@ struct ComposeAttach: AsyncParsableCommand {
     var service: String
 
     func run() async throws {
-        let (_, project) = try options.loadCompose()
+        let (_, project, _) = try options.loadCompose()
         let config = MockerConfig()
         let engine = try ContainerEngine(config: config)
         let idx = index ?? 1
@@ -1818,7 +1821,7 @@ struct ComposeVolumes: AsyncParsableCommand {
     var quiet = false
 
     func run() async throws {
-        let (composeFile, _) = try options.loadCompose()
+        let (composeFile, _, _) = try options.loadCompose()
         for (name, _) in composeFile.volumes {
             print(name)
         }

--- a/Sources/MockerKit/Compose/ComposeFile.swift
+++ b/Sources/MockerKit/Compose/ComposeFile.swift
@@ -20,6 +20,23 @@ public struct ComposeFile: Sendable {
     /// Default compose file names searched in order, matching Docker Compose V2 behaviour.
     public static let defaultFileNames = ["compose.yaml", "compose.yml", "docker-compose.yaml", "docker-compose.yml"]
 
+    /// Resolve the Docker Compose project directory: explicit flag → dir of first non-'-' '-f' entry → cwd.
+    public static func resolveProjectDirectory(explicit: String?, files: [String], cwd: String) -> URL {
+        let cwdURL = URL(fileURLWithPath: cwd, isDirectory: true)
+        if let explicit, !explicit.isEmpty {
+            return URL(fileURLWithPath: explicit, relativeTo: cwdURL).standardizedFileURL
+        }
+        if let firstReal = files.first(where: { $0 != "-" }) {
+            return URL(fileURLWithPath: firstReal, relativeTo: cwdURL).standardizedFileURL.deletingLastPathComponent()
+        }
+        return cwdURL
+    }
+
+    /// Normalize a directory basename to a compose project name (lowercase + spaces to dashes).
+    public static func normalizeProjectName(_ s: String) -> String {
+        s.lowercased().replacingOccurrences(of: " ", with: "-")
+    }
+
     /// Return the path of the first default compose file found in `directory`.
     public static func findDefault(in directory: String = FileManager.default.currentDirectoryPath) -> String? {
         for name in defaultFileNames {
@@ -31,8 +48,8 @@ public struct ComposeFile: Sendable {
         return nil
     }
 
-    /// Parse a docker-compose.yml file from a path.
-    public static func load(from path: String) throws -> ComposeFile {
+    /// Parse a compose file at 'path'. '.env' auto-discovery uses 'projectDir/.env'.
+    public static func load(from path: String, projectDir: URL) throws -> ComposeFile {
         let url = URL(fileURLWithPath: path)
         guard FileManager.default.fileExists(atPath: path) else {
             throw MockerError.composeFileNotFound(path)
@@ -40,8 +57,7 @@ public struct ComposeFile: Sendable {
 
         var content = try String(contentsOf: url, encoding: .utf8)
 
-        // Load .env file from same directory for variable substitution
-        let envFile = url.deletingLastPathComponent().appendingPathComponent(".env").path
+        let envFile = projectDir.appendingPathComponent(".env").path
         let dotEnv = loadDotEnv(from: envFile)
 
         // Substitute ${VAR:-default} and $VAR patterns before YAML parsing

--- a/Sources/MockerKit/Compose/ComposeOrchestrator.swift
+++ b/Sources/MockerKit/Compose/ComposeOrchestrator.swift
@@ -18,15 +18,18 @@ public actor ComposeOrchestrator {
     private let networkManager: NetworkManager
     private let volumeManager: VolumeManager
     private let projectName: String
+    private let projectDir: URL
 
     public init(
         projectName: String,
+        projectDir: URL,
         engine: ContainerEngine,
         imageManager: ImageManager,
         networkManager: NetworkManager,
         volumeManager: VolumeManager
     ) {
         self.projectName = projectName
+        self.projectDir = projectDir
         self.engine = engine
         self.imageManager = imageManager
         self.networkManager = networkManager
@@ -222,14 +225,15 @@ public actor ComposeOrchestrator {
                 shouldBuild = !existingImages.contains { ComposeService.imageMatches($0, tag: tag) }
             }
             if shouldBuild {
+                let absContext = ImageManager.resolveContextPath(context: build.context, cwd: projectDir.path)
                 let dockerfilePath = ImageManager.composeDockerfilePath(
-                    context: build.context,
+                    context: absContext,
                     dockerfile: build.dockerfile ?? "Dockerfile",
-                    cwd: FileManager.default.currentDirectoryPath
+                    cwd: projectDir.path
                 )
                 _ = try await imageManager.build(
                     tag: tag,
-                    context: build.context,
+                    context: absContext,
                     dockerfile: dockerfilePath,
                     buildArgs: build.argList,
                     target: build.target

--- a/Sources/MockerKit/Image/ImageManager.swift
+++ b/Sources/MockerKit/Image/ImageManager.swift
@@ -241,7 +241,8 @@ public actor ImageManager {
         return args
     }
 
-    static func resolveContextPath(context: String, cwd: String) -> String {
+    /// Resolve a build `context` to an absolute path anchored to `cwd`.
+    public static func resolveContextPath(context: String, cwd: String) -> String {
         guard !context.hasPrefix("/") else { return context }
         return URL(fileURLWithPath: cwd).appendingPathComponent(context).standardized.path
     }

--- a/Tests/MockerKitTests/ComposeFileTests.swift
+++ b/Tests/MockerKitTests/ComposeFileTests.swift
@@ -632,4 +632,220 @@ struct ComposeFileTests {
         try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
         return dir
     }
+
+    @Test("Explicit --project-directory wins over -f dir and cwd")
+    func resolveProjectDirectoryExplicitWins() {
+        let resolved = ComposeFile.resolveProjectDirectory(
+            explicit: "/tmp/sub",
+            files: ["/tmp/sub/dir/compose.yml"],
+            cwd: "/tmp/other"
+        )
+        #expect(resolved.path == "/tmp/sub")
+    }
+
+    @Test("First -f directory wins when no explicit flag")
+    func resolveProjectDirectoryFirstFileWins() {
+        let resolved = ComposeFile.resolveProjectDirectory(
+            explicit: nil,
+            files: ["/tmp/sub/dir/compose.yml"],
+            cwd: "/tmp/other"
+        )
+        #expect(resolved.path == "/tmp/sub/dir")
+    }
+
+    @Test("Empty explicit --project-directory is treated as absent, falls through to -f dir")
+    func resolveProjectDirectoryEmptyExplicitFallsThrough() {
+        let resolved = ComposeFile.resolveProjectDirectory(
+            explicit: "",
+            files: ["/tmp/dir/x.yml"],
+            cwd: "/tmp/other"
+        )
+        #expect(resolved.path == "/tmp/dir")
+    }
+
+    @Test("CWD wins when no explicit flag and no -f files")
+    func resolveProjectDirectoryCWDFallback() {
+        let resolved = ComposeFile.resolveProjectDirectory(
+            explicit: nil,
+            files: [],
+            cwd: "/tmp/myproject"
+        )
+        #expect(resolved.path == "/tmp/myproject")
+    }
+
+    @Test("Nonexistent explicit project-directory is accepted lazily")
+    func resolveProjectDirectoryLazyValidation() {
+        let resolved = ComposeFile.resolveProjectDirectory(
+            explicit: "/no/exist/path",
+            files: ["/tmp/proj/compose.yml"],
+            cwd: "/tmp/other"
+        )
+        #expect(resolved.path == "/no/exist/path")
+        #expect(resolved.lastPathComponent == "path")
+    }
+
+    @Test("Single -f - (stdin only) falls back to cwd")
+    func resolveProjectDirectoryStdinOnlyFallsBackToCWD() {
+        let resolved = ComposeFile.resolveProjectDirectory(
+            explicit: nil,
+            files: ["-"],
+            cwd: "/tmp/x"
+        )
+        #expect(resolved.path == "/tmp/x")
+    }
+
+    @Test("Mixed -f - -f file.yml resolves to the real file's dir (stdin first)")
+    func resolveProjectDirectoryMixedStdinFirst() {
+        let resolved = ComposeFile.resolveProjectDirectory(
+            explicit: nil,
+            files: ["-", "/tmp/dir/file.yml"],
+            cwd: "/tmp/other"
+        )
+        #expect(resolved.path == "/tmp/dir")
+    }
+
+    @Test("Mixed -f file.yml -f - resolves to the real file's dir (stdin last)")
+    func resolveProjectDirectoryMixedStdinLast() {
+        let resolved = ComposeFile.resolveProjectDirectory(
+            explicit: nil,
+            files: ["/tmp/dir/file.yml", "-"],
+            cwd: "/tmp/other"
+        )
+        #expect(resolved.path == "/tmp/dir")
+    }
+
+    @Test("All -f entries are - falls back to cwd")
+    func resolveProjectDirectoryAllStdinFallsBackToCWD() {
+        let resolved = ComposeFile.resolveProjectDirectory(
+            explicit: nil,
+            files: ["-", "-"],
+            cwd: "/tmp/x"
+        )
+        #expect(resolved.path == "/tmp/x")
+    }
+
+    @Test("Relative explicit --project-directory resolves against injected cwd, not process cwd")
+    func resolveProjectDirectoryRelativeExplicitHonorsCwd() {
+        let resolved = ComposeFile.resolveProjectDirectory(
+            explicit: "sub",
+            files: [],
+            cwd: "/tmp/myproject"
+        )
+        #expect(resolved.path == "/tmp/myproject/sub")
+    }
+
+    @Test("Relative first -f entry resolves against injected cwd, not process cwd")
+    func resolveProjectDirectoryRelativeFirstFileHonorsCwd() {
+        let resolved = ComposeFile.resolveProjectDirectory(
+            explicit: nil,
+            files: ["dir/compose.yml"],
+            cwd: "/tmp/myproject"
+        )
+        #expect(resolved.path == "/tmp/myproject/dir")
+    }
+
+    @Test("Injected cwd different from the real process cwd is honored")
+    func resolveProjectDirectoryHonorsInjectedCwdOverProcessCwd() {
+        let resolved = ComposeFile.resolveProjectDirectory(
+            explicit: "relative",
+            files: [],
+            cwd: "/tmp/not-the-real-cwd"
+        )
+        #expect(resolved.path == "/tmp/not-the-real-cwd/relative")
+        #expect(resolved.path != FileManager.default.currentDirectoryPath + "/relative")
+    }
+
+    @Test("Explicit flag + deeper compose file: name from flag's last component, not the file's parent")
+    func projectNameFromExplicitFlagNotFileParent() {
+        let projectDir = ComposeFile.resolveProjectDirectory(
+            explicit: "/tmp/myproj",
+            files: ["/tmp/myproj/deep/sub/compose.yml"],
+            cwd: "/tmp/other"
+        )
+        #expect(projectDir.lastPathComponent != "sub")
+        #expect(ComposeFile.normalizeProjectName(projectDir.lastPathComponent) == "myproj")
+    }
+
+    @Test("No flag, deeper compose file: name from first -f dir's last component")
+    func projectNameFromFirstFileDirWhenNoFlag() {
+        let projectDir = ComposeFile.resolveProjectDirectory(
+            explicit: nil,
+            files: ["/tmp/myproj/deep/sub/compose.yml"],
+            cwd: "/tmp/other"
+        )
+        #expect(ComposeFile.normalizeProjectName(projectDir.lastPathComponent) == "sub")
+    }
+
+    @Test("normalizeProjectName lowercases uppercase directory names")
+    func normalizeProjectNameLowercasesUppercase() {
+        #expect(ComposeFile.normalizeProjectName("MyProject") == "myproject")
+    }
+
+    @Test("normalizeProjectName replaces spaces with dashes")
+    func normalizeProjectNameReplacesSpaces() {
+        #expect(ComposeFile.normalizeProjectName("my project") == "my-project")
+    }
+
+    private static let substitutionYAML = """
+    services:
+      web:
+        image: alpine:${TAG:-fallback}
+    """
+
+    @Test(".env loaded from projectDir, not the compose file's own dir")
+    func envLoadedFromProjectDir() throws {
+        let root = try ComposeTestHelpers.makeProjectDir([
+            .file("sub/dir/compose.yml", Self.substitutionYAML),
+            .file("sub/dir/.env", "TAG=from_dir\n"),
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let composePath = root.appendingPathComponent("sub/dir/compose.yml").path
+        let projectDir = root.appendingPathComponent("sub/dir")
+        let compose = try ComposeFile.load(from: composePath, projectDir: projectDir)
+        #expect(compose.services["web"]?.image == "alpine:from_dir")
+    }
+
+    @Test("Explicit project-directory overrides .env source over first -f dir")
+    func envSourceFollowsExplicitProjectDirectory() throws {
+        let root = try ComposeTestHelpers.makeProjectDir([
+            .file("sub/dir/compose.yml", Self.substitutionYAML),
+            .file("sub/.env", "TAG=from_sub\n"),
+            .file("sub/dir/.env", "TAG=from_dir\n"),
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let composePath = root.appendingPathComponent("sub/dir/compose.yml").path
+        let projectDir = root.appendingPathComponent("sub")
+        let compose = try ComposeFile.load(from: composePath, projectDir: projectDir)
+        #expect(compose.services["web"]?.image == "alpine:from_sub")
+    }
+
+    @Test("CWD's .env is not loaded when project-dir is established via -f")
+    func envNotLoadedFromCWDWhenProjectDirFromFile() throws {
+        let root = try ComposeTestHelpers.makeProjectDir([
+            .file("sub/dir/compose.yml", Self.substitutionYAML),
+            .file("sub/dir/.env", "TAG=from_dir\n"),
+            .file("cwd/.env", "TAG=from_cwd\n"),
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let composePath = root.appendingPathComponent("sub/dir/compose.yml").path
+        let projectDir = root.appendingPathComponent("sub/dir")
+        let compose = try ComposeFile.load(from: composePath, projectDir: projectDir)
+        #expect(compose.services["web"]?.image == "alpine:from_dir")
+    }
+
+    @Test("Missing .env is silently skipped, no error")
+    func missingEnvSilentlySkipped() throws {
+        let root = try ComposeTestHelpers.makeProjectDir([
+            .file("proj/compose.yml", Self.substitutionYAML),
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let composePath = root.appendingPathComponent("proj/compose.yml").path
+        let projectDir = root.appendingPathComponent("proj")
+        let compose = try ComposeFile.load(from: composePath, projectDir: projectDir)
+        #expect(compose.services["web"]?.image == "alpine:fallback")
+    }
 }

--- a/Tests/MockerKitTests/ComposeFileTests.swift
+++ b/Tests/MockerKitTests/ComposeFileTests.swift
@@ -848,4 +848,55 @@ struct ComposeFileTests {
         let compose = try ComposeFile.load(from: composePath, projectDir: projectDir)
         #expect(compose.services["web"]?.image == "alpine:fallback")
     }
+
+    @Test("Env var in build.context substituted, then resolved against project-dir")
+    func buildContextEnvVarSubstitutedThenResolved() throws {
+        let root = try ComposeTestHelpers.makeProjectDir([
+            .file("proj/compose.yml", """
+                services:
+                  app:
+                    build:
+                      context: "${MYDIR}"
+                """),
+            .file("proj/.env", "MYDIR=./sub/app\n"),
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let composePath = root.appendingPathComponent("proj/compose.yml").path
+        let projectDir = root.appendingPathComponent("proj")
+        let compose = try ComposeFile.load(from: composePath, projectDir: projectDir)
+
+        // Substitution already ran during load() — the raw "${MYDIR}" literal is gone.
+        #expect(compose.services["app"]?.build?.context == "./sub/app")
+
+        let absContext = ImageManager.resolveContextPath(
+            context: compose.services["app"]!.build!.context, cwd: projectDir.path
+        )
+        #expect(absContext == projectDir.appendingPathComponent("sub/app").path)
+    }
+
+    @Test("Env var resolving to absolute path passes through unchanged after substitution")
+    func buildContextEnvVarAbsolutePassesThroughUnchanged() throws {
+        let root = try ComposeTestHelpers.makeProjectDir([
+            .file("proj/compose.yml", """
+                services:
+                  app:
+                    build:
+                      context: "${MYDIR}"
+                """),
+            .file("proj/.env", "MYDIR=/absolute/path/to/context\n"),
+        ])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let composePath = root.appendingPathComponent("proj/compose.yml").path
+        let projectDir = root.appendingPathComponent("proj")
+        let compose = try ComposeFile.load(from: composePath, projectDir: projectDir)
+
+        #expect(compose.services["app"]?.build?.context == "/absolute/path/to/context")
+
+        let absContext = ImageManager.resolveContextPath(
+            context: compose.services["app"]!.build!.context, cwd: projectDir.path
+        )
+        #expect(absContext == "/absolute/path/to/context")
+    }
 }

--- a/Tests/MockerKitTests/ComposeTestHelpers.swift
+++ b/Tests/MockerKitTests/ComposeTestHelpers.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+/// Declarative temp-directory tree builder for compose project-directory tests.
+enum ComposeTestHelpers {
+    /// A single file to materialize relative to a fixture root.
+    struct FileSpec {
+        let path: String
+        let content: String
+
+        static func file(_ path: String, _ content: String) -> FileSpec {
+            FileSpec(path: path, content: content)
+        }
+    }
+
+    /// Builds a fresh temp directory tree containing the given files and returns its root URL.
+    static func makeProjectDir(_ files: [FileSpec] = []) throws -> URL {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        for file in files {
+            let url = root.appendingPathComponent(file.path)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try file.content.write(to: url, atomically: true, encoding: .utf8)
+        }
+
+        return root
+    }
+}

--- a/Tests/MockerKitTests/ImageManagerBuildArgsTests.swift
+++ b/Tests/MockerKitTests/ImageManagerBuildArgsTests.swift
@@ -157,6 +157,22 @@ struct ImageManagerComposeDockerfilePathTests {
     }
 }
 
+@Suite("ImageManager Compose context path resolver")
+struct ImageManagerComposeContextPathTests {
+
+    @Test("relative context resolves against cwd")
+    func relativeContextResolvesAgainstCWD() {
+        let result = ImageManager.resolveContextPath(context: "../app", cwd: "/tmp/sub/dir")
+        #expect(result == "/tmp/sub/app")
+    }
+
+    @Test("absolute context passes through unchanged")
+    func absoluteContextPassesThroughUnchanged() {
+        let result = ImageManager.resolveContextPath(context: "/usr/local/src", cwd: "/tmp/sub/dir")
+        #expect(result == "/usr/local/src")
+    }
+}
+
 @Suite("ImageManager Dockerfile path resolver")
 struct ImageManagerDockerfileResolverTests {
 

--- a/Tests/MockerTests/CLITests.swift
+++ b/Tests/MockerTests/CLITests.swift
@@ -35,6 +35,29 @@ struct CLITests {
         #expect(command.detach == true)
     }
 
+    @Test("Compose subcommand accepts --project-directory flag")
+    func composeProjectDirectoryFlag() throws {
+        let command = try ComposePull.parse(["--project-directory", "/tmp/myproj", "-f", "a.yaml"])
+        #expect(command.options.projectDirectory == "/tmp/myproj")
+    }
+
+    @Test("loadCompose discovers the default file inside --project-directory when -f is omitted")
+    func loadComposeUsesProjectDirectoryForDefaultDiscovery() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let projectDir = root.appendingPathComponent("proj")
+        try FileManager.default.createDirectory(at: projectDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let composePath = projectDir.appendingPathComponent("compose.yml")
+        try "services:\n  web:\n    image: nginx:latest\n".write(to: composePath, atomically: true, encoding: .utf8)
+
+        let command = try ComposePull.parse(["--project-directory", projectDir.path])
+        let (composeFile, _, resolvedProjectDir) = try command.options.loadCompose()
+
+        #expect(resolvedProjectDir.path == projectDir.path)
+        #expect(composeFile.services["web"] != nil)
+    }
+
     @Test("Run command accepts nested virtualization flags")
     func runVirtualizationFlags() throws {
         let command = try Run.parse(["--virtualization", "--kernel", "/tmp/vmlinux", "ubuntu:latest"])


### PR DESCRIPTION
This PR was originally meant to close #49, but I hit a bunch of related project-directory anchoring issues along the way and got a bit (okay, a lot) sidetracked. I'm glad another contributor already handled #49 upstream while I was down that rabbit hole.

This is the first of a few Docker-parity fixes I'll be submitting. I'll do my best to stay on track for the next ones!

## What problem does this solve?

`mocker compose -f /projects/app/compose.yaml build` resolved `build.context: .` against the caller's CWD rather than the project root. From outside `/projects/app`, the build received the wrong source tree with no error. Silent wrong output. `.env` auto-discovery had the same flaw: it ran relative to each compose file's parent directory, so the active environment varied with the number and location of `-f` files in play.

Docker Compose defines a canonical project directory: the path given via `--project-directory`, else the directory of the first non-stdin `-f` file, else the process CWD. Every project-relative path (`build.context`, `dockerfile`, `.env`, the project name) must anchor there. Without this anchor, mocker's path resolution diverges from Docker Compose's behavior whenever the caller's CWD differs from the project root, making builds non-reproducible across environments.

## What changed

- Added `--project-directory <path>` to `mocker compose`, implementing Docker Compose's precedence rule: explicit flag > directory of the first real `-f` file (`"-"` stdin entries skipped) > process CWD. When no `-f` is given, default compose file discovery runs inside `projectDir` rather than the process CWD.
- `.env` discovery and the default project name now anchor to the resolved project directory. Previously `.env` was sought relative to each compose file's parent; now a single lookup runs against `projectDir`.
- `build.context` and the `dockerfile` path derived from it now resolve against the project directory instead of the process CWD. Builds invoked from outside the project root now receive consistent absolute paths regardless of caller CWD.
- `ComposeFile.load(from:projectDir:)` and `ComposeOrchestrator.init(...)` each take a required `projectDir: URL` parameter. `ImageManager.resolveContextPath` is promoted to `public` to support cross-module path resolution from the CLI layer.

## Breaking change

`.env` discovery and the default project name now derive from the resolved project directory rather than each compose file's parent. `build.context` and the `dockerfile` path now resolve against the project directory instead of the process CWD. For the common case (running `mocker compose` from the project root), behavior is unchanged. Callers that invoke `mocker compose` from a directory other than the project root should add `--project-directory <path>` and verify resolved paths with `mocker compose config`. MockerKit consumers: `ComposeFile.load(from:projectDir:)` and `ComposeOrchestrator.init(...)` each require a new `projectDir: URL` argument; callers that relied on implicit CWD anchoring must supply the directory explicitly.
