### PR TITLE
fix(publish): honor [host-ip:] prefix in -p and compose ports

### DIFF
--- a/Sources/Mocker/Commands/Create.swift
+++ b/Sources/Mocker/Commands/Create.swift
@@ -23,7 +23,7 @@ struct Create: AsyncParsableCommand {
     @Option(name: .long, help: "Read in a file of environment variables")
     var envFile: String?
 
-    @Option(name: .shortAndLong, parsing: .singleValue, help: "Publish container port (hostPort:containerPort)")
+    @Option(name: .shortAndLong, parsing: .singleValue, help: "Publish container port ([host-ip:]hostPort:containerPort[/protocol])")
     var publish: [String] = []
 
     @Option(name: .shortAndLong, parsing: .singleValue, help: "Bind mount a volume (source:destination[:ro])")

--- a/Sources/Mocker/Commands/Run.swift
+++ b/Sources/Mocker/Commands/Run.swift
@@ -32,7 +32,7 @@ struct Run: AsyncParsableCommand {
     @Option(name: .long, help: "Read in a file of environment variables")
     var envFile: String?
 
-    @Option(name: .shortAndLong, parsing: .singleValue, help: "Publish container port (hostPort:containerPort)")
+    @Option(name: .shortAndLong, parsing: .singleValue, help: "Publish container port ([host-ip:]hostPort:containerPort[/protocol])")
     var publish: [String] = []
 
     @Option(name: .shortAndLong, parsing: .singleValue, help: "Bind mount a volume (source:destination[:ro])")

--- a/Sources/MockerKit/API/DockerAPIMappers.swift
+++ b/Sources/MockerKit/API/DockerAPIMappers.swift
@@ -12,7 +12,7 @@ public func mapToContainerListItem(_ c: ContainerInfo) -> [String: Any] {
     let state = c.state == .stopped ? "exited" : c.state.rawValue
     let ports: [[String: Any]] = c.ports.map { p in
         [
-            "IP": "0.0.0.0",
+            "IP": p.hostIp ?? "0.0.0.0",
             "PrivatePort": Int(p.containerPort),
             "PublicPort": Int(p.hostPort),
             "Type": p.portProtocol.rawValue,

--- a/Sources/MockerKit/Container/ContainerEngine.swift
+++ b/Sources/MockerKit/Container/ContainerEngine.swift
@@ -92,7 +92,8 @@ public actor ContainerEngine {
         // host-reachable forwarding through vmnet — this is what actually makes
         // published ports reachable, for both `mocker run -p` and `compose up`.
         for port in containerConfig.ports {
-            args += ["-p", "\(port.hostPort):\(port.containerPort)/\(port.portProtocol.rawValue)"]
+            let hostPrefix = port.hostIp.map { "\($0):" } ?? ""
+            args += ["-p", "\(hostPrefix)\(port.hostPort):\(port.containerPort)/\(port.portProtocol.rawValue)"]
         }
 
         if let workingDir = containerConfig.workingDir, !workingDir.isEmpty {

--- a/Sources/MockerKit/Models/ContainerConfig.swift
+++ b/Sources/MockerKit/Models/ContainerConfig.swift
@@ -118,25 +118,31 @@ public struct PortMapping: Codable, Sendable, CustomStringConvertible {
     public var hostPort: UInt16
     public var containerPort: UInt16
     public var portProtocol: PortProtocol
+    /// Optional host IP to bind to (e.g. "127.0.0.1"). `nil` means the wildcard `0.0.0.0`.
+    public var hostIp: String?
 
-    public init(hostPort: UInt16, containerPort: UInt16, portProtocol: PortProtocol = .tcp) {
+    public init(
+        hostPort: UInt16, containerPort: UInt16, portProtocol: PortProtocol = .tcp, hostIp: String? = nil
+    ) {
         self.hostPort = hostPort
         self.containerPort = containerPort
         self.portProtocol = portProtocol
+        self.hostIp = hostIp
     }
 
     public var description: String {
-        "\(hostPort):\(containerPort)/\(portProtocol.rawValue)"
+        let hostPart = hostIp.map { "\($0):" } ?? ""
+        return "\(hostPart)\(hostPort):\(containerPort)/\(portProtocol.rawValue)"
     }
 
     /// Parse a port mapping string. Accepts the common Docker/Compose forms:
     ///   "80"                      -> same host and container port
     ///   "8080:80"                 -> explicit host:container
     ///   "8080:80/udp"             -> with protocol
-    ///   "127.0.0.1:8080:80"       -> host-ip:host:container (the host IP is accepted
-    ///                                but not bound separately; publishing host:container
-    ///                                already reaches localhost)
+    ///   "127.0.0.1:8080:80"       -> host-ip:host:container (binds only that host IP)
     /// Port ranges (e.g. "8000-8010:9000-9010") are not yet supported and throw.
+    /// ponytail: bracketed IPv6 host IPs (`[::1]:8080:80`) aren't parsed; split-on-`:`
+    /// only handles IPv4/hostname prefixes. Add a bracket-aware scan if IPv6 is needed.
     public static func parse(_ value: String) throws -> PortMapping {
         let parts = value.split(separator: "/")
         let proto: PortProtocol = parts.count > 1 ? (parts[1] == "udp" ? .udp : .tcp) : .tcp
@@ -156,12 +162,14 @@ public struct PortMapping: Codable, Sendable, CustomStringConvertible {
             }
             return PortMapping(hostPort: host, containerPort: container, portProtocol: proto)
         case 3:
-            // portParts[0] is the host IP (e.g. 127.0.0.1); it is not persisted because
-            // `container run -p host:container` already binds a host-reachable port.
-            guard let host = UInt16(portParts[1]), let container = UInt16(portParts[2]) else {
+            // portParts[0] is the host IP (e.g. 127.0.0.1); bound explicitly so callers can
+            // restrict a published port to loopback rather than the 0.0.0.0 wildcard.
+            let hostIp = String(portParts[0])
+            guard !hostIp.isEmpty,
+                let host = UInt16(portParts[1]), let container = UInt16(portParts[2]) else {
                 throw MockerError.invalidPortMapping(value)
             }
-            return PortMapping(hostPort: host, containerPort: container, portProtocol: proto)
+            return PortMapping(hostPort: host, containerPort: container, portProtocol: proto, hostIp: hostIp)
         default:
             throw MockerError.invalidPortMapping(value)
         }

--- a/Sources/MockerKit/Models/ContainerInspect.swift
+++ b/Sources/MockerKit/Models/ContainerInspect.swift
@@ -170,7 +170,7 @@ public func mapToContainerInspect(_ info: ContainerInfo) -> ContainerInspect {
         info.ports.map { port in
             (
                 "\(port.containerPort)/\(port.portProtocol.rawValue)",
-                [ContainerInspectPortBinding(hostIp: "0.0.0.0", hostPort: String(port.hostPort))]
+                [ContainerInspectPortBinding(hostIp: port.hostIp ?? "0.0.0.0", hostPort: String(port.hostPort))]
             )
         },
         uniquingKeysWith: { first, _ in first }

--- a/Tests/MockerKitTests/ContainerEngineTests.swift
+++ b/Tests/MockerKitTests/ContainerEngineTests.swift
@@ -206,6 +206,35 @@ struct ContainerEngineTests {
         if let idx { #expect(args[idx + 1] == "5353:53/udp") }
     }
 
+    @Test("Run arguments carry the host-IP prefix end-to-end (parse -> config -> -p)")
+    func testRunArgumentsPublishHostIP() throws {
+        // Full chain: the spec a user types, through PortMapping.parse, into the exact
+        // string handed to `container run -p`. Proves #55: the prefix is no longer dropped.
+        let config = ContainerConfig(
+            image: "nginx:alpine",
+            ports: [try PortMapping.parse("127.0.0.1:8080:80")]
+        )
+
+        let args = ContainerEngine.buildRunArguments(name: "web", config: config)
+
+        let idx = args.firstIndex(of: "-p")
+        #expect(idx != nil)
+        if let idx { #expect(args[idx + 1] == "127.0.0.1:8080:80/tcp") }
+    }
+
+    @Test("Run arguments omit host IP when unspecified (wildcard bind)")
+    func testRunArgumentsNoHostIP() {
+        let config = ContainerConfig(
+            image: "nginx:alpine",
+            ports: [PortMapping(hostPort: 8080, containerPort: 80)]
+        )
+        let args = ContainerEngine.buildRunArguments(name: "web", config: config)
+        let idx = args.firstIndex(of: "-p")
+        #expect(idx != nil)
+        // No leading IP — a bare host:container preserves the pre-#55 wildcard behavior.
+        if let idx { #expect(args[idx + 1] == "8080:80/tcp") }
+    }
+
     @Test("Run arguments omit -p when no ports requested")
     func testRunArgumentsNoPorts() {
         let config = ContainerConfig(image: "alpine")

--- a/Tests/MockerTests/FlagEnforcementTests.swift
+++ b/Tests/MockerTests/FlagEnforcementTests.swift
@@ -20,12 +20,28 @@ struct FlagEnforcementTests {
         #expect(pm.portProtocol == .udp)
     }
 
-    @Test("PortMapping parse with host IP prefix")
+    @Test("PortMapping parse with host IP prefix binds that IP")
     func testPortMappingWithHostIP() throws {
         let pm = try PortMapping.parse("127.0.0.1:8080:80")
         #expect(pm.hostPort == 8080)
         #expect(pm.containerPort == 80)
         #expect(pm.portProtocol == .tcp)
+        #expect(pm.hostIp == "127.0.0.1")
+        #expect(pm.description == "127.0.0.1:8080:80/tcp")
+    }
+
+    @Test("PortMapping host IP prefix with protocol")
+    func testPortMappingWithHostIPAndProtocol() throws {
+        let pm = try PortMapping.parse("127.0.0.1:5353:53/udp")
+        #expect(pm.hostIp == "127.0.0.1")
+        #expect(pm.hostPort == 5353)
+        #expect(pm.portProtocol == .udp)
+    }
+
+    @Test("PortMapping without host IP leaves hostIp nil (wildcard bind)")
+    func testPortMappingNoHostIPIsNil() throws {
+        #expect(try PortMapping.parse("8080:80").hostIp == nil)
+        #expect(try PortMapping.parse("80").hostIp == nil)
     }
 
     @Test("PortMapping parse bare container port maps host to same port")


### PR DESCRIPTION
Closes #55.

## Problem

`mocker run -p 127.0.0.1:8080:80` (and compose `ports:` entries with a host-IP prefix) parsed the leading `host-ip:` but then **discarded** it. Every published port bound the `0.0.0.0` wildcard, with no way to restrict a service to loopback. This is both a Docker/`apple/container` compatibility gap and a real security/robustness issue (LAN exposure + wildcard-vs-`127.0.0.1` port-squatting, described in #55).

## Fix

- `PortMapping` gains an optional `hostIp: String?` (nil = wildcard). The 3-part `host-ip:host:container` form now persists the IP instead of dropping it; empty IP is rejected.
- `container run -p` is invoked as `[host-ip:]hostPort:containerPort/proto`, forwarding the prefix the runtime already supports — covers both `mocker run -p` and `compose up`.
- Inspect (`HostIp`) and `list` (`IP`) output report the actual bound IP instead of a hardcoded `0.0.0.0`.
- `--help` text for `run`/`create` updated to `[host-ip:]hostPort:containerPort[/protocol]`.

## Not covered

Bracketed IPv6 host IPs (`[::1]:8080:80`) — the `split(":")` parser only handles IPv4/hostname prefixes. Marked with a `ponytail:` comment and an upgrade path; out of scope for #55 which asks for `127.0.0.1`.

## Tests

Updated the existing host-IP parse test to assert the IP is captured, plus new cases for host-IP + protocol, description round-trip, and nil-when-absent. Full suite green (268 tests).