### PR TITLE
feat(registry): keychain-backed registry authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ approach gives you a fully working Docker-compatible tool on macOS 26 today:
 - [x] `mocker build` — delegates to `container build` with live output
 - [x] `mocker stats` — real CPU% and memory from VM process
 - [x] Port mapping (`-p`) — userspace TCP proxy subprocess
-- [ ] Registry authentication (`mocker login`)
+- [x] Registry authentication (`mocker login` / `mocker logout`, keychain-backed)
 - [ ] `mocker compose --scale`
 - [ ] MenuBar live container metrics (CPU, memory, logs)
 - [ ] Image layer size reporting

--- a/Sources/Mocker/Commands/Login.swift
+++ b/Sources/Mocker/Commands/Login.swift
@@ -17,14 +17,32 @@ struct Login: AsyncParsableCommand {
     var passwordStdin = false
 
     @Argument(help: "Registry server (default: Docker Hub)")
-    var server: String = "https://index.docker.io/v1/"
+    var server: String = "docker.io"
 
     func run() async throws {
-        // Registry authentication is not yet wired into pull/push operations.
-        // Rather than silently storing credentials that are never used, fail explicitly.
-        throw MockerError.operationFailed(
-            "registry authentication is not yet supported by Mocker. " +
-            "Pull/push operations use anonymous access only."
-        )
+        var username = self.username
+        var password = self.password
+
+        if passwordStdin {
+            guard username != nil else {
+                throw MockerError.operationFailed("Must provide --username with --password-stdin")
+            }
+            guard let data = try FileHandle.standardInput.readToEnd() else {
+                throw MockerError.operationFailed("Failed to read password from stdin")
+            }
+            password = String(decoding: data, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        let resolvedUser = try username ?? RegistryAuth.promptUsername(server: server)
+        let resolvedPass: String
+        if let password {
+            resolvedPass = password
+        } else {
+            resolvedPass = try RegistryAuth.promptPassword()
+            print()
+        }
+
+        try await RegistryAuth.login(server: server, username: resolvedUser, password: resolvedPass)
+        print("Login succeeded")
     }
 }

--- a/Sources/Mocker/Commands/Logout.swift
+++ b/Sources/Mocker/Commands/Logout.swift
@@ -8,12 +8,10 @@ struct Logout: AsyncParsableCommand {
     )
 
     @Argument(help: "Registry server (default: Docker Hub)")
-    var server: String = "https://index.docker.io/v1/"
+    var server: String = "docker.io"
 
     func run() async throws {
-        throw MockerError.operationFailed(
-            "registry authentication is not yet supported by Mocker. " +
-            "Pull/push operations use anonymous access only."
-        )
+        try RegistryAuth.logout(server: server)
+        print("Removed login credentials for \(server)")
     }
 }

--- a/Sources/MockerKit/Image/ImageManager.swift
+++ b/Sources/MockerKit/Image/ImageManager.swift
@@ -27,7 +27,9 @@ public actor ImageManager {
             return (Self.toImageInfo(existing), true)
         }
 
-        let image = try await imageStore.pull(reference: normalized, platform: parsedPlatform)
+        let image = try await imageStore.pull(
+            reference: normalized, platform: parsedPlatform, auth: RegistryAuth.resolve(for: normalized)
+        )
         return (Self.toImageInfo(image), false)
     }
 
@@ -326,7 +328,9 @@ public actor ImageManager {
             throw MockerError.imageNotFound(reference)
         }
         let parsedPlatform = try platform.map { try ContainerizationOCI.Platform(from: $0) }
-        try await imageStore.push(reference: normalized, platform: parsedPlatform)
+        try await imageStore.push(
+            reference: normalized, platform: parsedPlatform, auth: RegistryAuth.resolve(for: normalized)
+        )
     }
 
     // MARK: - Save / Load

--- a/Sources/MockerKit/Image/RegistryAuth.swift
+++ b/Sources/MockerKit/Image/RegistryAuth.swift
@@ -1,0 +1,64 @@
+import Foundation
+import ContainerizationOCI
+import ContainerizationExtras
+
+/// Registry credentials backed by the macOS keychain.
+///
+/// mocker owns its own keychain security domain: `mocker login` / `mocker logout`
+/// manage entries here, and pull/push look them up automatically. This is separate
+/// from Apple's `container` CLI keychain, because mocker pulls images through the
+/// Containerization framework directly rather than shelling out to `container pull`.
+public enum RegistryAuth {
+    /// Keychain security domain that scopes all mocker registry credentials.
+    static let securityDomain = "com.mocker.cli"
+
+    private static var keychain: KeychainHelper {
+        KeychainHelper(securityDomain: securityDomain)
+    }
+
+    /// Stored credentials for the registry hosting `reference`, or nil for anonymous access.
+    /// `reference` should be a fully-qualified image reference (see `ImageManager.normalize`).
+    public static func resolve(for reference: String) -> Authentication? {
+        guard let host = try? Reference.parse(reference).resolvedDomain else { return nil }
+        return try? keychain.lookup(hostname: host)
+    }
+
+    /// Verify credentials against the registry, then persist them to the keychain.
+    public static func login(server: String, username: String, password: String) async throws {
+        let host = hostname(for: server)
+        let client = RegistryClient(
+            host: host,
+            authentication: BasicAuthentication(username: username, password: password),
+            tlsConfiguration: TLSUtils.makeEnvironmentAwareTLSConfiguration()
+        )
+        try await client.ping()
+        try keychain.save(hostname: host, username: username, password: password)
+    }
+
+    /// Remove stored credentials for `server`.
+    public static func logout(server: String) throws {
+        try keychain.delete(hostname: hostname(for: server))
+    }
+
+    /// Prompt stdin for a username (visible echo).
+    public static func promptUsername(server: String) throws -> String {
+        try keychain.userPrompt(hostname: server)
+    }
+
+    /// Prompt stdin for a password (echo disabled).
+    public static func promptPassword() throws -> String {
+        try keychain.passwordPrompt()
+    }
+
+    /// Reduce a user-supplied server (bare domain or full URL) to the keychain hostname,
+    /// matching how pull/push resolve the host from an image reference. This keeps the
+    /// `login` save key and the pull/push lookup key identical for Docker Hub, which the
+    /// framework resolves `docker.io` → `registry-1.docker.io`.
+    static func hostname(for server: String) -> String {
+        var s = server
+        if let scheme = s.range(of: "://") { s = String(s[scheme.upperBound...]) }
+        if let slash = s.firstIndex(of: "/") { s = String(s[..<slash]) }
+        if s.isEmpty || s == "index.docker.io" { s = "docker.io" }
+        return Reference.resolveDomain(domain: s)
+    }
+}

--- a/Tests/MockerKitTests/RegistryAuthTests.swift
+++ b/Tests/MockerKitTests/RegistryAuthTests.swift
@@ -1,0 +1,41 @@
+import Testing
+import ContainerizationOCI
+@testable import MockerKit
+
+@Suite("RegistryAuth hostname resolution")
+struct RegistryAuthTests {
+
+    @Test("bare docker.io resolves to registry-1.docker.io")
+    func dockerIoResolves() {
+        #expect(RegistryAuth.hostname(for: "docker.io") == "registry-1.docker.io")
+    }
+
+    @Test("empty server defaults to Docker Hub")
+    func emptyDefaultsToDockerHub() {
+        #expect(RegistryAuth.hostname(for: "") == "registry-1.docker.io")
+    }
+
+    @Test("legacy v1 URL host maps to Docker Hub")
+    func legacyURLMapsToDockerHub() {
+        #expect(RegistryAuth.hostname(for: "https://index.docker.io/v1/") == "registry-1.docker.io")
+    }
+
+    @Test("third-party registry passes through")
+    func thirdPartyPassesThrough() {
+        #expect(RegistryAuth.hostname(for: "ghcr.io") == "ghcr.io")
+    }
+
+    @Test("registry with path keeps only the host")
+    func stripsPath() {
+        #expect(RegistryAuth.hostname(for: "ghcr.io/owner") == "ghcr.io")
+    }
+
+    /// The keychain lookup key used by pull/push (via a normalized reference) must match
+    /// the save key used by `login` (via `hostname(for:)`), or credentials never resolve.
+    @Test("login save key matches pull lookup key for Docker Hub")
+    func loginKeyMatchesPullKey() throws {
+        let loginKey = RegistryAuth.hostname(for: "docker.io")
+        let pullKey = try ContainerizationOCI.Reference.parse("docker.io/library/alpine:latest").resolvedDomain
+        #expect(loginKey == pullKey)
+    }
+}


### PR DESCRIPTION
Closes #53.

## Problem

`mocker login` / `mocker logout` were stubs that threw *"registry authentication is not yet supported by Mocker. Pull/push operations use anonymous access only."* Private registries (ghcr.io, private Docker Hub repos) were unusable. `container registry login` didn't help because mocker pulls through the Containerization **framework** directly, not by shelling out to `container pull`, so it never saw those credentials.

## Fix

- New `RegistryAuth` helper in MockerKit wraps the framework's `KeychainHelper` under mocker's own keychain security domain (`com.mocker.cli`).
- `mocker login` prompts for (or accepts `-u` / `-p` / `--password-stdin`) credentials, verifies them against the registry (`RegistryClient.ping()`), then saves to the keychain.
- `mocker logout` removes them (no-op-safe when absent).
- `ImageManager.pull` / `push` now resolve stored credentials for the target registry and pass them as `auth:` — anonymous access is preserved when nothing is stored.

## Key correctness point

The keychain **save** key (from `login`'s server arg) and the **lookup** key (from a normalized image reference on pull/push) must be identical or credentials silently never resolve. Both go through the framework's domain resolution, including Docker Hub's `docker.io` → `registry-1.docker.io`. A unit test pins this invariant.

## Scope / notes

- macOS keychain only (mocker is macOS-only). Separate from Apple's `container` CLI keychain by design — mocker owns its credentials because it pulls via the framework.
- No env-var credential override (e.g. `REGISTRY_TOKEN`) — YAGNI; can add for CI if requested.
- `hostname()` resolution is unit-tested (5 cases + the save/lookup-parity test). The full login→pull round-trip needs a real registry + keychain and isn't covered by automated tests.

## Tests

6 new tests, full suite green (272). Verified `login --help` and `logout <missing>` behavior against the built binary.