### PR TITLE
feat(compose): read stdin content from `-f -`

### DIFF
--- a/Sources/Mocker/Commands/Compose.swift
+++ b/Sources/Mocker/Commands/Compose.swift
@@ -49,7 +49,7 @@ struct ComposeCommand: AsyncParsableCommand {
 // MARK: - Shared Options
 
 struct ComposeOptions: ParsableArguments {
-    @Option(name: [.customShort("f"), .long], parsing: .singleValue,
+    @Option(name: [.customShort("f"), .long, .customLong("file")], parsing: .singleValue,
             help: "Compose file path (repeatable; later files override earlier)")
     var files: [String] = []
 

--- a/Sources/Mocker/Commands/Compose.swift
+++ b/Sources/Mocker/Commands/Compose.swift
@@ -76,7 +76,14 @@ struct ComposeOptions: ParsableArguments {
             paths = files
         }
 
-        let loaded = try paths.map { try ComposeFile.load(from: $0, projectDir: projectDir) }
+        let loaded = try paths.map { entry -> ComposeFile in
+            if entry == "-" {
+                let data = try FileHandle.standardInput.readToEnd() ?? Data()
+                let content = String(decoding: data, as: UTF8.self)
+                return try ComposeFile.load(content: content, projectDir: projectDir)
+            }
+            return try ComposeFile.load(from: entry, projectDir: projectDir)
+        }
         let composeFile = ComposeFile.merge(loaded)
 
         let project = projectName ?? ComposeFile.normalizeProjectName(projectDir.lastPathComponent)

--- a/Sources/MockerKit/Compose/ComposeFile.swift
+++ b/Sources/MockerKit/Compose/ComposeFile.swift
@@ -55,15 +55,27 @@ public struct ComposeFile: Sendable {
             throw MockerError.composeFileNotFound(path)
         }
 
-        var content = try String(contentsOf: url, encoding: .utf8)
+        let content = try String(contentsOf: url, encoding: .utf8)
+        return try parseAndSubstitute(content: content, projectDir: projectDir)
+    }
 
+    /// Parse a compose file from an in-memory string (stdin `-f -`).
+    /// '.env' auto-discovery uses 'projectDir/.env'. Throws if content is empty.
+    public static func load(content: String, projectDir: URL) throws -> ComposeFile {
+        if content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            throw MockerError.composeParseError("compose file content is empty")
+        }
+        return try parseAndSubstitute(content: content, projectDir: projectDir)
+    }
+
+    private static func parseAndSubstitute(content: String, projectDir: URL) throws -> ComposeFile {
         let envFile = projectDir.appendingPathComponent(".env").path
         let dotEnv = loadDotEnv(from: envFile)
 
         // Substitute ${VAR:-default} and $VAR patterns before YAML parsing
-        content = substituteVariables(in: content, dotEnv: dotEnv)
+        let substituted = substituteVariables(in: content, dotEnv: dotEnv)
 
-        return try parse(content)
+        return try parse(substituted)
     }
 
     /// Load key=value pairs from a .env file.

--- a/Tests/MockerKitTests/ComposeFileTests.swift
+++ b/Tests/MockerKitTests/ComposeFileTests.swift
@@ -899,4 +899,54 @@ struct ComposeFileTests {
         )
         #expect(absContext == "/absolute/path/to/context")
     }
+
+    @Test("load(content:): valid YAML string parses like a file")
+    func loadContentStdinHappyPath() throws {
+        let root = try ComposeTestHelpers.makeProjectDir([])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let projectDir = root.appendingPathComponent("sliceb_sa", isDirectory: true)
+        let yaml = """
+        services:
+          web:
+            image: alpine
+        """
+        let compose = try ComposeFile.load(content: yaml, projectDir: projectDir)
+        #expect(compose.services["web"]?.image == "alpine")
+    }
+
+    @Test("load(content:): empty string throws composeParseError with empty detail")
+    func loadContentEmptyStdinThrows() throws {
+        let root = try ComposeTestHelpers.makeProjectDir([])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let projectDir = root.appendingPathComponent("sliceb_sb", isDirectory: true)
+        #expect(throws: MockerError.self) {
+            _ = try ComposeFile.load(content: "", projectDir: projectDir)
+        }
+        do {
+            _ = try ComposeFile.load(content: "", projectDir: projectDir)
+            Issue.record("expected throw")
+        } catch let error as MockerError {
+            #expect(error.errorDescription?.contains("compose file content is empty") == true)
+        } catch {
+            Issue.record("unexpected error type: \(error)")
+        }
+    }
+
+    @Test("load(content:): whitespace-only content throws the same empty-stdin error")
+    func loadContentWhitespaceOnlyStdinThrows() throws {
+        let root = try ComposeTestHelpers.makeProjectDir([])
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let projectDir = root.appendingPathComponent("sliceb_sc", isDirectory: true)
+        do {
+            _ = try ComposeFile.load(content: "  \n\n  ", projectDir: projectDir)
+            Issue.record("expected throw")
+        } catch let error as MockerError {
+            #expect(error.errorDescription?.contains("compose file content is empty") == true)
+        } catch {
+            Issue.record("unexpected error type: \(error)")
+        }
+    }
 }

--- a/Tests/MockerTests/CLITests.swift
+++ b/Tests/MockerTests/CLITests.swift
@@ -28,6 +28,18 @@ struct CLITests {
         #expect(command.options.files == ["a.yaml", "b.yaml"])
     }
 
+    @Test("Compose subcommand accepts --file long flag (Docker parity)")
+    func composeFileLongFlag() throws {
+        let command = try ComposePull.parse(["--file", "a.yaml"])
+        #expect(command.options.files == ["a.yaml"])
+    }
+
+    @Test("Compose subcommand accepts --file mixed with -f")
+    func composeFileLongAndShort() throws {
+        let command = try ComposePull.parse(["-f", "a.yaml", "--file", "b.yaml"])
+        #expect(command.options.files == ["a.yaml", "b.yaml"])
+    }
+
     @Test("Compose up parses -f together with a subcommand flag")
     func composeUpFileAndFlag() throws {
         let command = try ComposeUp.parse(["-f", "docker-compose.yml", "--detach"])


### PR DESCRIPTION
## What problem does this solve?

`cat docker-compose.yml | mocker compose config -f -` fails with `Error: no configuration file provided: not found: -` and exit 1. Docker compose accepts stdin via `-f -` as documented in its CLI reference, so any user migrating a shell script or a CI/CD pipe hits a Docker-parity gap on their first invocation against mocker.

The same trap exists for heredocs (`mocker compose -f - config <<'EOF' ... EOF`), for piping templated output (`gomplate ... | mocker compose -f - up`), and for mixing a file with an override supplied via stdin (`-f base.yml -f -` to merge). Today every one of these paths lands on the same `not found: -` error because `loadCompose()` calls `ComposeFile.load(from: "-", ...)` which has no stdin-reading branch.

## What changed

- Add a public `ComposeFile.load(content:projectDir:)` overload that takes an in-memory YAML string. The `.env` discovery and variable substitution pipeline are factored into a private `parseAndSubstitute(content:projectDir:)` helper that the existing `load(from:projectDir:)` now delegates to (no behavior change to file loading).
- Wire the stdin branch in `loadCompose()`: when an entry in `-f` is `"-"`, read with `FileHandle.standardInput.readToEnd()` (mirroring `Login.swift:30`'s established pattern) and route the bytes through the new overload. Absolute paths and the default-file path pass through unchanged.
- Empty or whitespace-only stdin surfaces as `MockerError.composeParseError("compose file content is empty")` — the existing case, not a new enum variant. Empty stdin and empty file are the same failure mode (input that cannot be parsed), so both paths share the error category; the detail message tells the user which one fired.
- Multi-stdin (`-f - -f -` in the same invocation) is undefined: the second read returns empty bytes and triggers the empty-stdin error. Use each `-f -` once per invocation, which is what the upstream compose reference documents.