### PR TITLE
fix(compose): mount named volumes so data survives --force-recreate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **image inspect:** `mocker image inspect` and `mocker inspect --type=image` now return Docker-compatible `ImageInspect` JSON arrays with PascalCase keys instead of the previous lowercase `ImageInfo` object shape.
 * **MockerKit:** `ImageManager.inspect(_:platform:)` returns `ImageInspect` instead of `ImageInfo`.
 
-### Bug Fixes
-
-* **compose:** named volumes are now mounted into containers, so their data survives `compose up --force-recreate` instead of silently living in the container layer and being discarded. Volumes resolve to their backing directory under the volume store (`<volumesPath>/<runtimeName>/_data`), matching Docker's behaviour; `down --volumes` still removes them.
-
 ## [0.9.1](https://github.com/us/mocker/compare/v0.9.0...v0.9.1) (2026-08-09)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * **image inspect:** `mocker image inspect` and `mocker inspect --type=image` now return Docker-compatible `ImageInspect` JSON arrays with PascalCase keys instead of the previous lowercase `ImageInfo` object shape.
 * **MockerKit:** `ImageManager.inspect(_:platform:)` returns `ImageInspect` instead of `ImageInfo`.
 
+### Bug Fixes
+
+* **compose:** named volumes are now mounted into containers, so their data survives `compose up --force-recreate` instead of silently living in the container layer and being discarded. Volumes resolve to their backing directory under the volume store (`<volumesPath>/<runtimeName>/_data`), matching Docker's behaviour; `down --volumes` still removes them.
+
 ## [0.9.1](https://github.com/us/mocker/compare/v0.9.0...v0.9.1) (2026-08-09)
 
 

--- a/Sources/MockerKit/Compose/ComposeOrchestrator.swift
+++ b/Sources/MockerKit/Compose/ComposeOrchestrator.swift
@@ -523,7 +523,13 @@ public actor ComposeOrchestrator {
         // Parse port mappings
         let ports = try service.ports.map { try PortMapping.parse($0) }
 
-        let volumes = try Self.resolveVolumeMounts(service.volumes, projectDir: projectDir)
+        let volumes = try Self.resolveVolumeMounts(
+            service.volumes,
+            projectDir: projectDir,
+            projectName: projectName,
+            declaredVolumes: composeFile.volumes,
+            volumesPath: volumeManager.mountpointPath
+        )
 
         let config = ContainerConfig(
             name: containerName,
@@ -563,33 +569,53 @@ public actor ComposeOrchestrator {
 
     /// Resolve volume spec strings from a compose service into `VolumeMount` values.
     ///
-    /// Bind-mount host paths (absolute or relative) are included; anonymous volumes
-    /// (container paths only) are included; named volumes (bare names without path
-    /// separators) are skipped — Apple's virtiofs doesn't support chown from within
-    /// containers, which breaks images like postgres that chown their data directory
-    /// on init.
+    /// Bind-mount host paths (absolute, relative or `~`-anchored) and anonymous
+    /// volumes (container paths only) are included as-is. Named volumes are
+    /// resolved to their backing directory under `volumesPath`
+    /// (`<volumesPath>/<runtimeName>/_data`, where `runtimeName` applies the
+    /// project prefix unless the volume declares an explicit `name:` or is
+    /// `external:`), and bind-mounted — exactly what Docker does internally, and
+    /// what keeps the data alive across `compose up --force-recreate`.
     ///
     /// Relative paths (`./foo`, `../bar`, `data/dir`) are resolved to absolute paths
     /// against `projectDir` (the Compose `--project-directory`, i.e. the directory
     /// containing the compose file unless overridden). This matches Docker Compose
     /// behaviour, where bind-mount sources are anchored to the project directory
     /// rather than the process's current working directory.
-    static func resolveVolumeMounts(_ volSpecs: [String], projectDir: URL) throws -> [VolumeMount] {
+    static func resolveVolumeMounts(
+        _ volSpecs: [String],
+        projectDir: URL,
+        projectName: String,
+        declaredVolumes: [String: ComposeVolume],
+        volumesPath: String
+    ) throws -> [VolumeMount] {
         var volumes: [VolumeMount] = []
         for volSpec in volSpecs {
             var mount = try VolumeMount.parse(volSpec)
             if mount.source.isEmpty {
+                // Anonymous volume: just a container path.
                 volumes.append(mount)
             } else if mount.source.hasPrefix("/") {
+                // Absolute bind mount.
                 volumes.append(mount)
             } else if mount.source.hasPrefix("~") {
+                // Home-relative bind mount.
                 mount.source = (mount.source as NSString).expandingTildeInPath
                 volumes.append(mount)
             } else if mount.source.hasPrefix(".")
                       || mount.source.contains("/") {
+                // Relative bind mount, anchored to the project directory.
                 mount.source = projectDir.appendingPathComponent(mount.source).standardized.path
                 volumes.append(mount)
+            } else if let declared = declaredVolumes[mount.source] {
+                // Named volume: bind-mount the volume's backing directory so the
+                // data survives container recreation (issue #XX).
+                let runtimeName = declared.runtimeName(projectName: projectName)
+                mount.source = "\(volumesPath)/\(runtimeName)/_data"
+                volumes.append(mount)
             }
+            // Anything else (e.g. an undeclared bare name) is silently dropped,
+            // matching the previous behaviour for non-declared names.
         }
         return volumes
     }

--- a/Sources/MockerKit/Compose/ComposeOrchestrator.swift
+++ b/Sources/MockerKit/Compose/ComposeOrchestrator.swift
@@ -81,6 +81,21 @@ public actor ComposeOrchestrator {
             }
         }
 
+        // Named volumes are bind-mounted from their backing directory, so both an
+        // unusable name and a missing external volume have to fail here — before any
+        // service starts — rather than as a raw runtime path error half-way through.
+        if !composeFile.volumes.isEmpty {
+            let existing = Set(await volumeManager.list().map(\.name))
+            for volume in composeFile.volumes.values {
+                let name = volume.runtimeName(projectName: projectName)
+                _ = try volumeManager.mountpoint(name)
+                guard !volume.external || existing.contains(name) else {
+                    throw MockerError.operationFailed(
+                        "volume \(name) declared as external, but could not be found")
+                }
+            }
+        }
+
         // Create networks
         for (fullName, driver) in Self.networksToCreate(composeFile: composeFile, projectName: projectName) {
             do {
@@ -523,12 +538,14 @@ public actor ComposeOrchestrator {
         // Parse port mappings
         let ports = try service.ports.map { try PortMapping.parse($0) }
 
+        // Named volumes bind-mount their backing directory, exactly as Docker does
+        // internally, so the data survives container recreation.
         let volumes = try Self.resolveVolumeMounts(
             service.volumes,
             projectDir: projectDir,
-            projectName: projectName,
-            declaredVolumes: composeFile.volumes,
-            volumesPath: volumeManager.mountpointPath
+            namedVolumeSources: composeFile.volumes.mapValues {
+                try volumeManager.mountpoint($0.runtimeName(projectName: projectName))
+            }
         )
 
         let config = ContainerConfig(
@@ -569,13 +586,11 @@ public actor ComposeOrchestrator {
 
     /// Resolve volume spec strings from a compose service into `VolumeMount` values.
     ///
-    /// Bind-mount host paths (absolute, relative or `~`-anchored) and anonymous
-    /// volumes (container paths only) are included as-is. Named volumes are
-    /// resolved to their backing directory under `volumesPath`
-    /// (`<volumesPath>/<runtimeName>/_data`, where `runtimeName` applies the
-    /// project prefix unless the volume declares an explicit `name:` or is
-    /// `external:`), and bind-mounted — exactly what Docker does internally, and
-    /// what keeps the data alive across `compose up --force-recreate`.
+    /// Bind-mount host paths and anonymous volumes (container paths only) are
+    /// included as-is. A name declared in the file's top-level `volumes:` section is
+    /// bind-mounted from its backing directory (`namedVolumeSources`), which is what
+    /// keeps the data alive across `compose up --force-recreate`; an undeclared bare
+    /// name has no backing directory and is dropped.
     ///
     /// Relative paths (`./foo`, `../bar`, `data/dir`) are resolved to absolute paths
     /// against `projectDir` (the Compose `--project-directory`, i.e. the directory
@@ -585,21 +600,14 @@ public actor ComposeOrchestrator {
     static func resolveVolumeMounts(
         _ volSpecs: [String],
         projectDir: URL,
-        projectName: String,
-        declaredVolumes: [String: ComposeVolume],
-        volumesPath: String
+        namedVolumeSources: [String: String]
     ) throws -> [VolumeMount] {
         var volumes: [VolumeMount] = []
         for volSpec in volSpecs {
             var mount = try VolumeMount.parse(volSpec)
-            if mount.source.isEmpty {
-                // Anonymous volume: just a container path.
-                volumes.append(mount)
-            } else if mount.source.hasPrefix("/") {
-                // Absolute bind mount.
+            if mount.source.isEmpty || mount.source.hasPrefix("/") {
                 volumes.append(mount)
             } else if mount.source.hasPrefix("~") {
-                // Home-relative bind mount.
                 mount.source = (mount.source as NSString).expandingTildeInPath
                 volumes.append(mount)
             } else if mount.source.hasPrefix(".")
@@ -607,15 +615,10 @@ public actor ComposeOrchestrator {
                 // Relative bind mount, anchored to the project directory.
                 mount.source = projectDir.appendingPathComponent(mount.source).standardized.path
                 volumes.append(mount)
-            } else if let declared = declaredVolumes[mount.source] {
-                // Named volume: bind-mount the volume's backing directory so the
-                // data survives container recreation (issue #XX).
-                let runtimeName = declared.runtimeName(projectName: projectName)
-                mount.source = "\(volumesPath)/\(runtimeName)/_data"
+            } else if let source = namedVolumeSources[mount.source] {
+                mount.source = source
                 volumes.append(mount)
             }
-            // Anything else (e.g. an undeclared bare name) is silently dropped,
-            // matching the previous behaviour for non-declared names.
         }
         return volumes
     }

--- a/Sources/MockerKit/Volume/VolumeManager.swift
+++ b/Sources/MockerKit/Volume/VolumeManager.swift
@@ -28,6 +28,11 @@ public actor VolumeManager {
         }
     }
 
+    /// Root directory where volume data lives (`<dataRoot>/volumes`). Every named
+    /// volume is stored under `<mountpointPath>/<name>/_data`, which is what compose
+    /// bind-mounts into containers so named volumes survive container recreation.
+    public nonisolated var mountpointPath: String { storagePath }
+
     /// Reject names that would escape the volumes directory. Every volume path is
     /// built by interpolating the name, and a compose file can supply it verbatim
     /// (`volumes: {data: {name: ...}}`), so `../` must never get through.

--- a/Sources/MockerKit/Volume/VolumeManager.swift
+++ b/Sources/MockerKit/Volume/VolumeManager.swift
@@ -28,19 +28,23 @@ public actor VolumeManager {
         }
     }
 
-    /// Root directory where volume data lives (`<dataRoot>/volumes`). Every named
-    /// volume is stored under `<mountpointPath>/<name>/_data`, which is what compose
-    /// bind-mounts into containers so named volumes survive container recreation.
-    public nonisolated var mountpointPath: String { storagePath }
+    /// Backing directory holding a volume's data. Compose bind-mounts it so named
+    /// volumes survive container recreation.
+    public nonisolated func mountpoint(_ name: String) throws -> String {
+        try Self.validateName(name)
+        return "\(storagePath)/\(name)/_data"
+    }
 
     /// Reject names that would escape the volumes directory. Every volume path is
     /// built by interpolating the name, and a compose file can supply it verbatim
     /// (`volumes: {data: {name: ...}}`), so `../` must never get through.
     static func validateName(_ name: String) throws {
-        // Only path escape is rejected — anything else stays removable, including
-        // volumes created before this check existed.
+        // Path escape and `:` are rejected — the latter because the backing directory
+        // goes into a `-v source:destination` argument, where it would misparse.
+        // Anything else stays removable, including volumes created before this check.
         let valid = !name.isEmpty
             && !name.contains("/")
+            && !name.contains(":")
             && name != "."
             && name != ".."
         guard valid else {
@@ -50,12 +54,11 @@ public actor VolumeManager {
 
     /// Create a new volume.
     public func create(name: String, driver: String = "local", labels: [String: String] = [:]) throws -> VolumeInfo {
-        try Self.validateName(name)
         guard volumes[name] == nil else {
             throw MockerError.operationFailed("Volume \(name) already exists")
         }
 
-        let mountpoint = "\(config.volumesPath)/\(name)/_data"
+        let mountpoint = try mountpoint(name)
         let fm = FileManager.default
         if !fm.fileExists(atPath: mountpoint) {
             try fm.createDirectory(atPath: mountpoint, withIntermediateDirectories: true)

--- a/Tests/MockerKitTests/ComposeOrchestratorTests.swift
+++ b/Tests/MockerKitTests/ComposeOrchestratorTests.swift
@@ -161,7 +161,7 @@ struct ComposeOrchestratorTests {
 
     @Test("Absolute bind mount included as-is")
     func resolveAbsoluteBindMount() throws {
-        let mounts = try ComposeOrchestrator.resolveVolumeMounts(["/host/data:/container/data"], projectDir: Self.cwd)
+        let mounts = try Self.resolve(["/host/data:/container/data"])
         #expect(mounts.count == 1)
         #expect(mounts[0].source == "/host/data")
         #expect(mounts[0].destination == "/container/data")
@@ -176,22 +176,48 @@ struct ComposeOrchestratorTests {
         ]
     )
     func resolveRelativeStyleMounts(spec: String, suffix: String, destination: String) throws {
-        let mounts = try ComposeOrchestrator.resolveVolumeMounts([spec], projectDir: Self.cwd)
+        let mounts = try Self.resolve([spec])
         #expect(mounts.count == 1)
         #expect(mounts[0].source.hasPrefix("/"))
         #expect(mounts[0].source.hasSuffix(suffix))
         #expect(mounts[0].destination == destination)
     }
 
-    @Test("Named volume skipped")
-    func skipNamedVolume() throws {
-        let mounts = try ComposeOrchestrator.resolveVolumeMounts(["mydata:/container/data"], projectDir: Self.cwd)
+    @Test("Declared named volume resolved to its backing directory")
+    func resolveDeclaredNamedVolume() throws {
+        let mounts = try Self.resolve(["mydata:/container/data"], declared: ["mydata"])
+        #expect(mounts.count == 1)
+        #expect(mounts[0].source == "/volumes/proj-mydata/_data")
+        #expect(mounts[0].destination == "/container/data")
+    }
+
+    @Test("Named volume with explicit name uses it verbatim")
+    func resolveNamedVolumeCustomName() throws {
+        let vol = ComposeVolume(name: "mydata", customName: "shared-data")
+        let mounts = try Self.resolve(["mydata:/container/data"], declaredVolumes: ["mydata": vol])
+        #expect(mounts.count == 1)
+        #expect(mounts[0].source == "/volumes/shared-data/_data")
+        #expect(mounts[0].destination == "/container/data")
+    }
+
+    @Test("External named volume keeps its declared key")
+    func resolveExternalNamedVolume() throws {
+        let vol = ComposeVolume(name: "mydata", external: true)
+        let mounts = try Self.resolve(["mydata:/container/data"], declaredVolumes: ["mydata": vol])
+        #expect(mounts.count == 1)
+        #expect(mounts[0].source == "/volumes/mydata/_data")
+        #expect(mounts[0].destination == "/container/data")
+    }
+
+    @Test("Undeclared bare name is dropped")
+    func dropUndeclaredName() throws {
+        let mounts = try Self.resolve(["mydata:/container/data"])
         #expect(mounts.isEmpty)
     }
 
     @Test("Anonymous volume included")
     func includeAnonymousVolume() throws {
-        let mounts = try ComposeOrchestrator.resolveVolumeMounts(["/container/data"], projectDir: Self.cwd)
+        let mounts = try Self.resolve(["/container/data"])
         #expect(mounts.count == 1)
         #expect(mounts[0].source == "")
         #expect(mounts[0].destination == "/container/data")
@@ -199,16 +225,17 @@ struct ComposeOrchestratorTests {
 
     @Test("Mix of bind mounts, named volumes, and anonymous volumes")
     func resolveMixedVolumes() throws {
-        let mounts = try ComposeOrchestrator.resolveVolumeMounts([
+        let mounts = try Self.resolve([
             "/abs/path:/app/data",
             "./relative:/app/rel",
             "namedvol:/app/named",
             "/app/anon",
             "sub/dir:/app/sub",
-        ], projectDir: Self.cwd)
-        #expect(mounts.count == 4)  // namedvol skipped
+        ], declared: ["namedvol"])
+        #expect(mounts.count == 5)
         let sources = mounts.map(\.source)
         #expect(sources.contains("/abs/path"))
+        #expect(sources.contains("/volumes/proj-namedvol/_data"))
         #expect(sources.contains(""))  // anonymous
         #expect(sources.contains(where: { $0.hasSuffix("/relative") }))
         #expect(sources.contains(where: { $0.hasSuffix("sub/dir") }))
@@ -216,7 +243,7 @@ struct ComposeOrchestratorTests {
 
     @Test("Read-only relative bind mount preserves ro flag")
     func resolveRelativeReadOnly() throws {
-        let mounts = try ComposeOrchestrator.resolveVolumeMounts(["./data:/container/data:ro"], projectDir: Self.cwd)
+        let mounts = try Self.resolve(["./data:/container/data:ro"])
         #expect(mounts.count == 1)
         #expect(mounts[0].readOnly == true)
         #expect(mounts[0].destination == "/container/data")
@@ -225,11 +252,37 @@ struct ComposeOrchestratorTests {
 
     @Test("Home-relative path resolved")
     func resolveHomeRelativePath() throws {
-        let mounts = try ComposeOrchestrator.resolveVolumeMounts(["~/data:/container/data"], projectDir: Self.cwd)
+        let mounts = try Self.resolve(["~/data:/container/data"])
         #expect(mounts.count == 1)
         #expect(mounts[0].source.hasPrefix("/"))
         #expect(mounts[0].source.contains("data"))
         #expect(mounts[0].destination == "/container/data")
+    }
+
+    /// Convenience wrapper: resolve specs with a fixed project name/volumes path
+    /// and no declared volumes.
+    private static func resolve(
+        _ specs: [String],
+        declared declaredKeys: [String] = []
+    ) throws -> [VolumeMount] {
+        let declared = Dictionary(uniqueKeysWithValues: declaredKeys.map {
+            ($0, ComposeVolume(name: $0))
+        })
+        return try resolve(specs, declaredVolumes: declared)
+    }
+
+    /// Convenience wrapper with an explicit volume declaration map.
+    private static func resolve(
+        _ specs: [String],
+        declaredVolumes: [String: ComposeVolume]
+    ) throws -> [VolumeMount] {
+        try ComposeOrchestrator.resolveVolumeMounts(
+            specs,
+            projectDir: Self.cwd,
+            projectName: "proj",
+            declaredVolumes: declaredVolumes,
+            volumesPath: "/volumes"
+        )
     }
 
     // MARK: - reconcileDecision (issue #59)
@@ -488,7 +541,10 @@ struct ComposeOrchestratorTests {
         let projectDir = URL(fileURLWithPath: "/tmp/mocker-issue-60-project")
         let mounts = try ComposeOrchestrator.resolveVolumeMounts(
             ["./data:/container/data"],
-            projectDir: projectDir
+            projectDir: projectDir,
+            projectName: "proj",
+            declaredVolumes: [:],
+            volumesPath: "/volumes"
         )
         #expect(mounts.count == 1)
         #expect(mounts[0].source == "/tmp/mocker-issue-60-project/data")
@@ -500,7 +556,10 @@ struct ComposeOrchestratorTests {
         let projectDir = URL(fileURLWithPath: "/tmp/mocker-issue-60-project/nested")
         let mounts = try ComposeOrchestrator.resolveVolumeMounts(
             ["../shared:/container/shared"],
-            projectDir: projectDir
+            projectDir: projectDir,
+            projectName: "proj",
+            declaredVolumes: [:],
+            volumesPath: "/volumes"
         )
         #expect(mounts.count == 1)
         #expect(mounts[0].source == "/tmp/mocker-issue-60-project/shared")

--- a/Tests/MockerKitTests/ComposeOrchestratorTests.swift
+++ b/Tests/MockerKitTests/ComposeOrchestratorTests.swift
@@ -185,27 +185,9 @@ struct ComposeOrchestratorTests {
 
     @Test("Declared named volume resolved to its backing directory")
     func resolveDeclaredNamedVolume() throws {
-        let mounts = try Self.resolve(["mydata:/container/data"], declared: ["mydata"])
+        let mounts = try Self.resolve(["mydata:/container/data"], named: ["mydata": "/volumes/proj-mydata/_data"])
         #expect(mounts.count == 1)
         #expect(mounts[0].source == "/volumes/proj-mydata/_data")
-        #expect(mounts[0].destination == "/container/data")
-    }
-
-    @Test("Named volume with explicit name uses it verbatim")
-    func resolveNamedVolumeCustomName() throws {
-        let vol = ComposeVolume(name: "mydata", customName: "shared-data")
-        let mounts = try Self.resolve(["mydata:/container/data"], declaredVolumes: ["mydata": vol])
-        #expect(mounts.count == 1)
-        #expect(mounts[0].source == "/volumes/shared-data/_data")
-        #expect(mounts[0].destination == "/container/data")
-    }
-
-    @Test("External named volume keeps its declared key")
-    func resolveExternalNamedVolume() throws {
-        let vol = ComposeVolume(name: "mydata", external: true)
-        let mounts = try Self.resolve(["mydata:/container/data"], declaredVolumes: ["mydata": vol])
-        #expect(mounts.count == 1)
-        #expect(mounts[0].source == "/volumes/mydata/_data")
         #expect(mounts[0].destination == "/container/data")
     }
 
@@ -231,7 +213,7 @@ struct ComposeOrchestratorTests {
             "namedvol:/app/named",
             "/app/anon",
             "sub/dir:/app/sub",
-        ], declared: ["namedvol"])
+        ], named: ["namedvol": "/volumes/proj-namedvol/_data"])
         #expect(mounts.count == 5)
         let sources = mounts.map(\.source)
         #expect(sources.contains("/abs/path"))
@@ -259,29 +241,16 @@ struct ComposeOrchestratorTests {
         #expect(mounts[0].destination == "/container/data")
     }
 
-    /// Convenience wrapper: resolve specs with a fixed project name/volumes path
-    /// and no declared volumes.
+    /// Resolve specs against the test project directory, with named volumes already
+    /// mapped to their backing directories.
     private static func resolve(
         _ specs: [String],
-        declared declaredKeys: [String] = []
-    ) throws -> [VolumeMount] {
-        let declared = Dictionary(uniqueKeysWithValues: declaredKeys.map {
-            ($0, ComposeVolume(name: $0))
-        })
-        return try resolve(specs, declaredVolumes: declared)
-    }
-
-    /// Convenience wrapper with an explicit volume declaration map.
-    private static func resolve(
-        _ specs: [String],
-        declaredVolumes: [String: ComposeVolume]
+        named: [String: String] = [:]
     ) throws -> [VolumeMount] {
         try ComposeOrchestrator.resolveVolumeMounts(
             specs,
             projectDir: Self.cwd,
-            projectName: "proj",
-            declaredVolumes: declaredVolumes,
-            volumesPath: "/volumes"
+            namedVolumeSources: named
         )
     }
 
@@ -542,9 +511,7 @@ struct ComposeOrchestratorTests {
         let mounts = try ComposeOrchestrator.resolveVolumeMounts(
             ["./data:/container/data"],
             projectDir: projectDir,
-            projectName: "proj",
-            declaredVolumes: [:],
-            volumesPath: "/volumes"
+            namedVolumeSources: [:]
         )
         #expect(mounts.count == 1)
         #expect(mounts[0].source == "/tmp/mocker-issue-60-project/data")
@@ -557,9 +524,7 @@ struct ComposeOrchestratorTests {
         let mounts = try ComposeOrchestrator.resolveVolumeMounts(
             ["../shared:/container/shared"],
             projectDir: projectDir,
-            projectName: "proj",
-            declaredVolumes: [:],
-            volumesPath: "/volumes"
+            namedVolumeSources: [:]
         )
         #expect(mounts.count == 1)
         #expect(mounts[0].source == "/tmp/mocker-issue-60-project/shared")

--- a/Tests/MockerKitTests/ComposeVolumeLifecycleTests.swift
+++ b/Tests/MockerKitTests/ComposeVolumeLifecycleTests.swift
@@ -94,7 +94,7 @@ struct ComposeVolumeLifecycleTests {
     }
 
     @Test("Volume names that would escape the volumes directory are rejected", arguments: [
-        "../etc", "a/b", "..", ".", "",
+        "../etc", "a/b", "..", ".", "", "host:path",
     ])
     func rejectsEscapingVolumeNames(name: String) {
         #expect(throws: MockerError.self) {


### PR DESCRIPTION
## Problem

Named volumes declared in a `docker-compose.yaml` are **silently skipped** by `mocker compose up`. The volume store directory is created (you can see it under `~/.mocker/volumes/<project>-<name>/_data`), but it is never bind-mounted into the container.

The consequence is severe for stateful services:

- Writes go to the **container's ephemeral layer**, not to the volume.
- Any container recreation — `compose up --force-recreate`, a changed config hash, `compose down && compose up` — **discards the data**.
- MySQL, Postgres, Redis, etc. come back empty with no warning at all.

I hit this in production dev: a MySQL stack lost its entire database on `--force-recreate`, and every named volume under `~/.mocker/volumes/` was 0 bytes — proof they were never written to.

## Root cause

`ComposeOrchestrator.resolveVolumeMounts` (ComposeOrchestrator.swift:564) intentionally drops named volumes:

```
// named volumes (bare names without path separators) are skipped — Apple's
// virtiofs doesn't support chown from within containers, which breaks images
// like postgres that chown their data directory on init.
```

The skip was added in `c0934d8` as a revert of `a87cf87` (which had the right idea). The virtiofs/chown concern is real but applies **equally to regular bind mounts**, which compose already supports and which demonstrably work — including for postgres-style images. Silently losing data on every recreation is the worse failure mode, and the volume store directory is owned by the host user (exactly what `mocker run -v name:/path` already relies on).

## Fix

Named volumes are now resolved to their backing directory and bind-mounted, exactly like Docker does internally:

- `name:/container/path` → `-v <volumesPath>/<runtimeName>/_data:/container/path`
- `runtimeName` applies the project prefix unless the volume declares an explicit `name:` or is `external:` (reusing the existing `ComposeVolume.runtimeName(projectName:)` logic, so `compose down --volumes` removal stays in sync).

### Changes

| File | Change |
|---|---|
| `Sources/MockerKit/Compose/ComposeOrchestrator.swift` | `resolveVolumeMounts` now takes `projectName`, `declaredVolumes` and `volumesPath`; declared named volumes resolve to `<volumesPath>/<runtimeName>/_data`. Undeclared bare names are still dropped (previous behaviour). |
| `Sources/MockerKit/Volume/VolumeManager.swift` | Expose `mountpointPath` (nonisolated) so compose can resolve volume backing dirs. |
| `Tests/MockerKitTests/ComposeOrchestratorTests.swift` | Replaced the old "named volume skipped" expectation with coverage for declared, custom-named, external, undeclared, and mixed specs. |

## Verification

- **Unit**: `swift test` — 448 tests in 35 suites, all green.
- **Integration** (alpine with a named volume):
  ```bash
  services:
    app:
      image: alpine:3.20
      command: ["sh", "-c", "echo hello > /data/hello.txt && sleep 5 && cat /data/hello.txt"]
      volumes:
        - mydata:/data
  volumes:
    mydata:
  ```
  1. `mocker compose up` → `hello.txt` appears in `~/.mocker/volumes/<project>-mydata/_data/` (previously the volume stayed empty).
  2. `mocker compose up --force-recreate` → `hello.txt` **survives** (previously the data was lost).
  3. `mocker compose down --volumes` → volume removed, as expected.

## Notes / trade-offs

- Images that chown their data dir on init (e.g. official `postgres`) may need the host directory to be writable by the container user — the same constraint regular bind mounts already impose today. If virtiofs chown support is added later, no further changes are needed here.
- Behavior is now consistent with Docker Compose: named volumes persist across recreation and are removed only by `down --volumes`.

---

## Maintainer follow-up (second commit)

Reviewed and revised on top of the original fix. The mounting behaviour is unchanged; what changed is where failures surface and how the resolution is wired.

| Change | Why |
|---|---|
| `up()` validates every declared volume before creating networks, volumes or containers | A name that cannot become a host path (e.g. `name: "${VOL}"` with `VOL` unset) used to abort mid-way, after unrelated services had already started |
| Missing `external: true` volume now errors with `volume <name> declared as external, but could not be found` | Matches the Compose spec and the external-network check this repo already had; previously it failed with a raw `path ... does not exist` from the runtime |
| Volume names containing `:` are rejected | The backing directory goes into a `-v source:destination` argument, where a `:` misparses |
| `resolveVolumeMounts` takes resolved backing directories instead of `projectName` + `declaredVolumes` + `volumesPath` | The `<store>/<name>/_data` layout now lives in `VolumeManager.mountpoint` only, instead of being spelled out in two files |
| Hand-written `CHANGELOG.md` entry removed | release-please generates it from the commit |

### Upgrade note

The reconcile hash is computed from the service definition, so a container created by an older build is **not** recreated by `compose up` alone. Existing stateful containers keep running without the mount until they are recreated once (`compose up --force-recreate`, or `compose down` then `up`). New projects get the mount immediately.

### Known gaps, deliberately left out of this PR

- An **undeclared** bare name is still dropped silently. Docker Compose hard-fails (`service X refers to undefined volume Y`), which is the correct end state, but it would break compose files that run today. Tracked separately.
- Long volume syntax (`type: volume`, `read_only:`) is still stringified by the parser, so only short syntax reaches this code. Pre-existing.
- `mocker run -v name:/path` still passes the bare name to the runtime rather than resolving it. Pre-existing.

### Verification

- `swift test`: 446 tests in 35 suites, green.
- Real binary, alpine service with `mydata:/data`: `compose up` writes into `~/.mocker/volumes/<project>-mydata/_data/`; `compose up --force-recreate` keeps the first run's line and appends the second; `compose down --volumes` removes the directory.
- Missing external volume and unresolved `name:` both abort with zero side effects: no network created, no container started, including sibling services that declare no volumes.
