### PR TITLE
fix(inspect): report the applied memory limit in HostConfig

### DIFF
--- a/Sources/MockerKit/Container/ContainerEngine.swift
+++ b/Sources/MockerKit/Container/ContainerEngine.swift
@@ -691,6 +691,9 @@ extension ContainerEngine {
         let networks = (statusObj?["networks"] as? [[String: Any]]) ?? []
         let rawAddr = (networks.first?["ipv4Address"] as? String) ?? ""
         let addr = rawAddr.split(separator: "/").first.map(String.init) ?? rawAddr
+        // Memory limit: Apple's inspect reports it under `configuration.resources.memoryInBytes`
+        // (only when the container was created with an explicit limit).
+        let memoryBytes = ((cfg["resources"] as? [String: Any])?["memoryInBytes"] as? NSNumber)?.uint64Value
         return ContainerInfo(
             id: (cfg["id"] as? String) ?? id,
             name: name,
@@ -701,7 +704,8 @@ extension ContainerEngine {
             ports: config.ports,
             labels: config.labels,
             command: config.command.joined(separator: " "),
-            networkAddress: addr
+            networkAddress: addr,
+            memoryBytes: memoryBytes
         )
     }
 }

--- a/Sources/MockerKit/Models/ContainerInfo.swift
+++ b/Sources/MockerKit/Models/ContainerInfo.swift
@@ -14,6 +14,9 @@ public struct ContainerInfo: Codable, Sendable, Identifiable {
     public var pid: Int?
     /// Container IP address assigned by vmnet (Apple Containerization).
     public var networkAddress: String
+    /// Memory limit in bytes reported by the runtime (`configuration.resources.memoryInBytes`).
+    /// `nil` when the container has no explicit limit (runtime default).
+    public var memoryBytes: UInt64?
 
     public init(
         id: String,
@@ -26,7 +29,8 @@ public struct ContainerInfo: Codable, Sendable, Identifiable {
         labels: [String: String] = [:],
         command: String = "",
         pid: Int? = nil,
-        networkAddress: String = ""
+        networkAddress: String = "",
+        memoryBytes: UInt64? = nil
     ) {
         self.id = id
         self.name = name
@@ -39,6 +43,7 @@ public struct ContainerInfo: Codable, Sendable, Identifiable {
         self.command = command
         self.pid = pid
         self.networkAddress = networkAddress
+        self.memoryBytes = memoryBytes
     }
 
     /// Short ID (first 12 characters).

--- a/Sources/MockerKit/Models/ContainerInspect.swift
+++ b/Sources/MockerKit/Models/ContainerInspect.swift
@@ -6,7 +6,7 @@ import Foundation
 /// Serializes with Docker PascalCase JSON keys; optional fields are omitted when absent.
 ///
 /// Populated from the data mocker tracks in `ContainerInfo`. Fields that Apple's
-/// Containerization runtime does not surface (HostConfig, Mounts, RestartCount, env,
+/// Containerization runtime does not surface (Mounts, RestartCount, env,
 /// exit code, start/finish timestamps, …) are omitted rather than fabricated.
 public struct ContainerInspect: Codable, Sendable {
     enum CodingKeys: String, CodingKey {
@@ -17,6 +17,7 @@ public struct ContainerInspect: Codable, Sendable {
         case state = "State"
         case config = "Config"
         case networkSettings = "NetworkSettings"
+        case hostConfig = "HostConfig"
     }
 
     public let id: String
@@ -28,6 +29,7 @@ public struct ContainerInspect: Codable, Sendable {
     public let state: ContainerInspectState
     public let config: ContainerInspectConfig
     public let networkSettings: ContainerInspectNetworkSettings
+    public let hostConfig: ContainerInspectHostConfig
 
     public init(
         id: String,
@@ -36,7 +38,8 @@ public struct ContainerInspect: Codable, Sendable {
         image: String,
         state: ContainerInspectState,
         config: ContainerInspectConfig,
-        networkSettings: ContainerInspectNetworkSettings
+        networkSettings: ContainerInspectNetworkSettings,
+        hostConfig: ContainerInspectHostConfig
     ) {
         self.id = id
         self.created = created
@@ -45,6 +48,30 @@ public struct ContainerInspect: Codable, Sendable {
         self.state = state
         self.config = config
         self.networkSettings = networkSettings
+        self.hostConfig = hostConfig
+    }
+}
+
+/// Docker-compatible `HostConfig` sub-object.
+///
+/// `Memory` mirrors the limit the runtime actually applied
+/// (`configuration.resources.memoryInBytes`), 0 when the container has no
+/// explicit limit (Docker parity: `Memory` is an int64, 0 = no limit).
+/// `NetworkMode` is always "default": Apple Containerization has no custom
+/// network modes (Docker also emits "default" for the bridge).
+public struct ContainerInspectHostConfig: Codable, Sendable {
+    enum CodingKeys: String, CodingKey {
+        case memory = "Memory"
+        case networkMode = "NetworkMode"
+    }
+
+    /// Memory limit in bytes; 0 when no explicit limit was set.
+    public let memory: Int64
+    public let networkMode: String
+
+    public init(memory: Int64, networkMode: String) {
+        self.memory = memory
+        self.networkMode = networkMode
     }
 }
 
@@ -181,6 +208,11 @@ public func mapToContainerInspect(_ info: ContainerInfo) -> ContainerInspect {
         ports: ports
     )
 
+    let hostConfig = ContainerInspectHostConfig(
+        memory: Int64(info.memoryBytes ?? 0),
+        networkMode: "default"
+    )
+
     return ContainerInspect(
         id: info.id,
         created: rfc3339String(info.created),
@@ -188,7 +220,8 @@ public func mapToContainerInspect(_ info: ContainerInfo) -> ContainerInspect {
         image: info.image,
         state: state,
         config: config,
-        networkSettings: networkSettings
+        networkSettings: networkSettings,
+        hostConfig: hostConfig
     )
 }
 

--- a/Tests/MockerKitTests/ContainerEngineDecodeInspectTests.swift
+++ b/Tests/MockerKitTests/ContainerEngineDecodeInspectTests.swift
@@ -15,7 +15,8 @@ struct ContainerEngineDecodeInspectTests {
         state: String? = "running",
         ipv4Address: String? = "10.0.0.1/24",
         networks: [[String: Any]]? = nil,
-        configID: String = "abc123def456ghi"
+        configID: String = "abc123def456ghi",
+        memoryInBytes: Int? = nil
     ) -> [String: Any] {
         var statusObj: [String: Any] = [:]
         if let state { statusObj["state"] = state }
@@ -28,8 +29,12 @@ struct ContainerEngineDecodeInspectTests {
             nets = []
         }
         statusObj["networks"] = nets
+        var configuration: [String: Any] = ["id": configID]
+        if let memoryInBytes {
+            configuration["resources"] = ["memoryInBytes": memoryInBytes]
+        }
         return [
-            "configuration": ["id": configID] as [String: Any],
+            "configuration": configuration,
             "status": statusObj
         ]
     }
@@ -146,5 +151,21 @@ struct ContainerEngineDecodeInspectTests {
         // ContainerState.exited.displayString — if the constant ever drifts
         // back to "Exited (0)" or similar, both paths regress.
         #expect(ContainerState.exited.displayString == "Exited")
+    }
+
+    // MARK: - Memory limit
+
+    @Test("decodeInspect with resources.memoryInBytes surfaces the applied limit")
+    func decodeInspect_withMemoryLimit_surfacesMemoryBytes() {
+        let dict = makeDict(state: "running", memoryInBytes: 4_294_967_296) // 4 GiB
+        let result = ContainerEngine.decodeInspect(dict, id: "id1", name: "ctn", config: makeConfig())
+        #expect(result?.memoryBytes == 4_294_967_296)
+    }
+
+    @Test("decodeInspect without resources reports nil memory (runtime default)")
+    func decodeInspect_withoutMemoryLimit_reportsNil() {
+        let dict = makeDict(state: "running", memoryInBytes: nil)
+        let result = ContainerEngine.decodeInspect(dict, id: "id1", name: "ctn", config: makeConfig())
+        #expect(result?.memoryBytes == nil)
     }
 }

--- a/Tests/MockerKitTests/ContainerInspectMappingTests.swift
+++ b/Tests/MockerKitTests/ContainerInspectMappingTests.swift
@@ -95,4 +95,32 @@ struct ContainerInspectMappingTests {
         #expect(json.contains("\"80/tcp\""))
         #expect(!json.contains("\"status\""))  // not the internal lowercase shape
     }
+
+    // MARK: - HostConfig
+
+    @Test("HostConfig.Memory mirrors the applied limit; 0 when none (Docker parity)")
+    func hostConfigMemory() {
+        var info = sampleInfo()
+        info.memoryBytes = 4_294_967_296
+        let limited = mapToContainerInspect(info)
+        #expect(limited.hostConfig.memory == 4_294_967_296)
+        #expect(limited.hostConfig.networkMode == "default")
+
+        info.memoryBytes = nil
+        let unlimited = mapToContainerInspect(info)
+        #expect(unlimited.hostConfig.memory == 0)
+        #expect(unlimited.hostConfig.networkMode == "default")
+    }
+
+    @Test("HostConfig serializes with Docker PascalCase keys")
+    func hostConfigJsonShape() throws {
+        var info = sampleInfo()
+        info.memoryBytes = 4_294_967_296
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        let json = String(data: try encoder.encode(mapToContainerInspect(info)), encoding: .utf8)!
+        #expect(json.contains("\"HostConfig\":"))
+        #expect(json.contains("\"Memory\":4294967296"))
+        #expect(json.contains("\"NetworkMode\":\"default\""))
+    }
 }


### PR DESCRIPTION
<summary>

The memory limit set via `mocker run -m` (or compose `mem_limit`/`deploy.resources.limits.memory`) was applied by the runtime but **never surfaced in `mocker inspect`**: `HostConfig` was omitted from the inspect DTO, so `mocker inspect --format '{{.HostConfig.Memory}}'` (and the Docker API inspect endpoint) always returned empty — making it look like the limit was not applied (e.g. debugging a TigerBeetle container that hangs without its 4G limit).

## Change

- `ContainerInfo` gains `memoryBytes` — parsed in `decodeInspect` from the value the Apple CLI already reports (`configuration.resources.memoryInBytes`).
- `ContainerInspect` gains a Docker-shaped `HostConfig` (`Memory` int64, `0` when no limit; `NetworkMode` `"default"`), populated in `mapToContainerInspect`.
- Both `mocker inspect` and the Docker API inspect endpoint now expose `HostConfig.Memory`.

## Verified

- 458/458 Swift tests pass, including new coverage:
  - `decodeInspect` parses `resources.memoryInBytes` and returns nil without it.
  - `mapToContainerInspect` maps the limit to `HostConfig.Memory` (0 when none).
  - JSON shape uses Docker PascalCase keys (`HostConfig.Memory` / `HostConfig.NetworkMode`).
- End-to-end: `mocker run -m 4G ...` then `mocker inspect --format '{{.HostConfig.Memory}}'` → `4294967296` (previously empty).

💘 Generated with Crush